### PR TITLE
Add me query unit tests

### DIFF
--- a/backend/src/auth/auth.resolver.spec.ts
+++ b/backend/src/auth/auth.resolver.spec.ts
@@ -1,0 +1,31 @@
+import { AuthResolver } from './auth.resolver';
+import { AuthService } from './auth.service';
+import { UserModel } from '../users/models/user.model';
+
+describe('AuthResolver.me', () => {
+  const authService = {
+    register: jest.fn(),
+    login: jest.fn(),
+    refresh: jest.fn(),
+  };
+
+  const createResolver = () => new AuthResolver(authService as unknown as AuthService);
+
+  it('returns the current user when provided in context', () => {
+    const resolver = createResolver();
+    const user = {
+      id: 'user-1',
+      email: 'test@example.com',
+      username: 'testuser',
+    } as UserModel;
+
+    expect(resolver.me(user)).toBe(user);
+  });
+
+  it('returns null when no user is in context', () => {
+    const resolver = createResolver();
+
+    expect(resolver.me(null)).toBeNull();
+  });
+});
+


### PR DESCRIPTION
This pull request adds unit tests for the `me` method in the `AuthResolver`. The tests verify that the method correctly returns the current user when present and returns `null` when no user is provided.

Testing improvements:

* Added a new test suite in `auth.resolver.spec.ts` to cover the `me` method in `AuthResolver`, ensuring it returns the user from context or `null` if not present.