### PR TITLE
Add refresh token unit tests

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -210,4 +210,88 @@ describe('AuthService.login', () => {
   });
 });
 
+describe('AuthService.refresh', () => {
+  const prisma = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  const jwt = {
+    signAsync: jest.fn(),
+    verifyAsync: jest.fn(),
+  };
+
+  const config = {
+    get: jest.fn(),
+  };
+
+  const createService = () => new AuthService(prisma as any, jwt as any, config as any);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns new tokens and rotates refresh token', async () => {
+    jwt.verifyAsync.mockResolvedValue({ sub: 'user-1' });
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      username: 'testuser',
+      refreshTokenHash: 'refresh-hash',
+    });
+    bcrypt.compare.mockResolvedValue(true);
+    jwt.signAsync.mockResolvedValueOnce('new-access').mockResolvedValueOnce('new-refresh');
+    bcrypt.hash.mockResolvedValue('new-refresh-hash');
+
+    const service = createService();
+
+    const result = await service.refresh({ refreshToken: 'old-refresh' });
+
+    expect(jwt.verifyAsync).toHaveBeenCalled();
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { id: 'user-1' } });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { refreshTokenHash: 'new-refresh-hash' },
+    });
+    expect(result).toEqual({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      user: {
+        id: 'user-1',
+        email: 'test@example.com',
+        username: 'testuser',
+        refreshTokenHash: 'refresh-hash',
+      },
+    });
+  });
+
+  it('throws when refresh token is invalid', async () => {
+    jwt.verifyAsync.mockResolvedValue({ sub: 'user-1' });
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      refreshTokenHash: 'refresh-hash',
+    });
+    bcrypt.compare.mockResolvedValue(false);
+
+    const service = createService();
+
+    await expect(service.refresh({ refreshToken: 'bad-refresh' })).rejects.toThrow(
+      new UnauthorizedException('Invalid refresh token')
+    );
+  });
+
+  it('throws when user or refresh hash is missing', async () => {
+    jwt.verifyAsync.mockResolvedValue({ sub: 'user-1' });
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    const service = createService();
+
+    await expect(service.refresh({ refreshToken: 'old-refresh' })).rejects.toThrow(
+      new UnauthorizedException('Invalid refresh token')
+    );
+  });
+});
+
 


### PR DESCRIPTION
This pull request adds comprehensive tests for the `AuthService.refresh` method, ensuring correct behavior for token rotation and error handling. The new tests cover scenarios for successful refresh, invalid tokens, and missing user data.

**AuthService.refresh tests:**

* Added a test to verify successful refresh token rotation, including updating the stored refresh token hash and returning new tokens and user data.
* Added tests to ensure the method throws an `UnauthorizedException` when the refresh token is invalid or when the user/refresh hash is missing.