### PR TITLE
Add auth middleware unit tests

### DIFF
--- a/backend/src/auth/auth.context.spec.ts
+++ b/backend/src/auth/auth.context.spec.ts
@@ -1,0 +1,65 @@
+import { AuthContextService } from './auth.context';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('AuthContextService', () => {
+  const authService = {
+    getAccessPayload: jest.fn(),
+  };
+
+  const prisma = {
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  const createService = () =>
+    new AuthContextService(authService as unknown as AuthService, prisma as unknown as PrismaService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null user when no token payload', async () => {
+    authService.getAccessPayload.mockResolvedValue(null);
+    const service = createService();
+
+    const result = await service.buildContext({ headers: {} });
+
+    expect(result.user).toBeNull();
+  });
+
+  it('returns null user when token version mismatches', async () => {
+    authService.getAccessPayload.mockResolvedValue({ userId: 'user-1', tokenVersion: 2 });
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      tokenVersion: 1,
+    });
+
+    const service = createService();
+
+    const result = await service.buildContext({ headers: { authorization: 'Bearer token' } });
+
+    expect(result.user).toBeNull();
+  });
+
+  it('returns user when token is valid', async () => {
+    authService.getAccessPayload.mockResolvedValue({ userId: 'user-1', tokenVersion: 1 });
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      tokenVersion: 1,
+    });
+
+    const service = createService();
+
+    const result = await service.buildContext({ headers: { authorization: 'Bearer token' } });
+
+    expect(result.user).toEqual({
+      id: 'user-1',
+      email: 'test@example.com',
+      tokenVersion: 1,
+    });
+  });
+});
+

--- a/backend/src/common/guards/gql-auth.guard.spec.ts
+++ b/backend/src/common/guards/gql-auth.guard.spec.ts
@@ -1,0 +1,89 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { GqlAuthGuard } from './gql-auth.guard';
+import { AuthService } from '../../auth/auth.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('GqlAuthGuard', () => {
+  const authService = {
+    getAccessPayload: jest.fn(),
+  };
+
+  const prisma = {
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  const createGuard = () =>
+    new GqlAuthGuard(authService as unknown as AuthService, prisma as unknown as PrismaService);
+
+  const createContext = () => ({
+    req: { headers: { authorization: 'Bearer token' } },
+    user: null,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when token payload is missing', async () => {
+    const guard = createGuard();
+    const gqlContext = createContext();
+    jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+      getContext: () => gqlContext,
+    } as any);
+
+    authService.getAccessPayload.mockResolvedValue(null);
+
+    await expect(guard.canActivate({} as any)).rejects.toThrow(
+      new UnauthorizedException('Unauthorized')
+    );
+  });
+
+  it('throws when user is missing', async () => {
+    const guard = createGuard();
+    const gqlContext = createContext();
+    jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+      getContext: () => gqlContext,
+    } as any);
+
+    authService.getAccessPayload.mockResolvedValue({ userId: 'user-1', tokenVersion: 0 });
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(guard.canActivate({} as any)).rejects.toThrow(
+      new UnauthorizedException('Unauthorized')
+    );
+  });
+
+  it('throws when token version mismatches', async () => {
+    const guard = createGuard();
+    const gqlContext = createContext();
+    jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+      getContext: () => gqlContext,
+    } as any);
+
+    authService.getAccessPayload.mockResolvedValue({ userId: 'user-1', tokenVersion: 2 });
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-1', tokenVersion: 1 });
+
+    await expect(guard.canActivate({} as any)).rejects.toThrow(
+      new UnauthorizedException('Unauthorized')
+    );
+  });
+
+  it('sets context user when valid', async () => {
+    const guard = createGuard();
+    const gqlContext = createContext();
+    jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+      getContext: () => gqlContext,
+    } as any);
+
+    const user = { id: 'user-1', tokenVersion: 1 };
+    authService.getAccessPayload.mockResolvedValue({ userId: 'user-1', tokenVersion: 1 });
+    prisma.user.findUnique.mockResolvedValue(user);
+
+    await expect(guard.canActivate({} as any)).resolves.toBe(true);
+    expect(gqlContext.user).toBe(user);
+  });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for authentication-related logic, specifically targeting the `AuthContextService` and the `GqlAuthGuard`. These tests ensure correct behavior for user authentication, token validation, and context setup, improving the reliability and maintainability of the authentication system.

**Authentication context tests:**

* Added tests for `AuthContextService` covering scenarios where the token payload is missing, the token version mismatches, or the token is valid, ensuring that the correct user is returned or null as appropriate (`backend/src/auth/auth.context.spec.ts`).

**GraphQL authentication guard tests:**

* Added tests for `GqlAuthGuard` to verify that unauthorized requests are correctly rejected when the token payload is missing, the user does not exist, or the token version mismatches, and that the context user is set correctly when authentication succeeds (`backend/src/common/guards/gql-auth.guard.spec.ts`).