### PR TITLE
Add workspace models and roles

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,8 @@ model User {
   avatar    String?
   createdAt DateTime @default(now())
   boards    Board[]
+  ownedWorkspaces Workspace[] @relation("WorkspaceOwner")
+  workspaceMemberships WorkspaceMember[]
 }
 
 model Board {
@@ -28,6 +30,32 @@ model Board {
   owner       User     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+enum WorkspaceRole {
+  OWNER
+  MEMBER
+}
+
+model Workspace {
+  id        String   @id @default(uuid())
+  name      String
+  ownerId   String
+  owner     User     @relation("WorkspaceOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  members   WorkspaceMember[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model WorkspaceMember {
+  userId      String
+  workspaceId String
+  role        WorkspaceRole
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@id([userId, workspaceId])
+  @@index([workspaceId])
 }
 
 

--- a/backend/src/workspaces/models/workspace-role.enum.spec.ts
+++ b/backend/src/workspaces/models/workspace-role.enum.spec.ts
@@ -1,0 +1,9 @@
+import { WorkspaceRole } from './workspace-role.enum';
+
+describe('WorkspaceRole', () => {
+  it('exposes OWNER and MEMBER roles', () => {
+    expect(WorkspaceRole.OWNER).toBe('OWNER');
+    expect(WorkspaceRole.MEMBER).toBe('MEMBER');
+  });
+});
+

--- a/backend/src/workspaces/models/workspace-role.enum.ts
+++ b/backend/src/workspaces/models/workspace-role.enum.ts
@@ -1,0 +1,5 @@
+export enum WorkspaceRole {
+  OWNER = 'OWNER',
+  MEMBER = 'MEMBER',
+}
+


### PR DESCRIPTION
This pull request introduces foundational support for workspaces and workspace membership in the backend. The changes include new Prisma models for workspaces, workspace members, and roles, as well as corresponding TypeScript enums and tests. These updates lay the groundwork for associating users with workspaces and managing their roles within them.

**Prisma schema changes:**

* Added `Workspace` and `WorkspaceMember` models, including fields for ownership, membership, and timestamps, as well as a new `WorkspaceRole` enum to represent user roles within a workspace.
* Updated the `User` model to include relations to owned workspaces and workspace memberships.

**Backend TypeScript changes:**

* Introduced a `WorkspaceRole` enum in TypeScript to mirror the Prisma enum.
* Added a unit test to ensure the `WorkspaceRole` enum exposes the correct roles.