### PR TITLE
Add deleteWorkspace mutation (owner only) with cascade delete

### DIFF
--- a/backend/src/workspaces/workspaces.resolver.spec.ts
+++ b/backend/src/workspaces/workspaces.resolver.spec.ts
@@ -8,6 +8,7 @@ describe('WorkspacesResolver', () => {
     myWorkspaces: jest.fn(),
     getWorkspace: jest.fn(),
     updateWorkspace: jest.fn(),
+    deleteWorkspace: jest.fn(),
   } as unknown as WorkspacesService;
   const resolver = new WorkspacesResolver(workspacesService);
 
@@ -63,6 +64,16 @@ describe('WorkspacesResolver', () => {
       'Updated Acme'
     );
     expect(result).toBe(updatedWorkspace);
+  });
+
+  it('deletes workspace for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    workspacesService.deleteWorkspace = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.deleteWorkspace('workspace-1', user);
+
+    expect(workspacesService.deleteWorkspace).toHaveBeenCalledWith('workspace-1', 'user-1');
+    expect(result).toBe(true);
   });
 });
 

--- a/backend/src/workspaces/workspaces.resolver.ts
+++ b/backend/src/workspaces/workspaces.resolver.ts
@@ -40,5 +40,11 @@ export class WorkspacesResolver {
   ) {
     return this.workspacesService.updateWorkspace(input.id, user.id, input.name);
   }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async deleteWorkspace(@Args('id') id: string, @Context('user') user: User) {
+    return this.workspacesService.deleteWorkspace(id, user.id);
+  }
 }
 

--- a/backend/src/workspaces/workspaces.service.spec.ts
+++ b/backend/src/workspaces/workspaces.service.spec.ts
@@ -9,6 +9,7 @@ describe('WorkspacesService', () => {
       create: jest.fn(),
       findUnique: jest.fn(),
       update: jest.fn(),
+      delete: jest.fn(),
     },
     workspaceMember: {
       findMany: jest.fn(),
@@ -164,6 +165,51 @@ describe('WorkspacesService', () => {
         ForbiddenException
       );
       expect(prisma.workspace.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteWorkspace', () => {
+    it('deletes workspace when user is owner', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-1',
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspace.delete = jest.fn().mockResolvedValue(workspace);
+
+      const result = await service.deleteWorkspace('workspace-1', 'user-1');
+
+      expect(prisma.workspace.findUnique).toHaveBeenCalledWith({
+        where: { id: 'workspace-1' },
+      });
+      expect(prisma.workspace.delete).toHaveBeenCalledWith({
+        where: { id: 'workspace-1' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when workspace does not exist', async () => {
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.deleteWorkspace('workspace-1', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.workspace.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not owner', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-2',
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+
+      await expect(service.deleteWorkspace('workspace-1', 'user-1')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.workspace.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/workspaces/workspaces.service.ts
+++ b/backend/src/workspaces/workspaces.service.ts
@@ -91,5 +91,28 @@ export class WorkspacesService {
       },
     });
   }
+
+  async deleteWorkspace(workspaceId: string, userId: string) {
+    const workspace = await this.prisma.workspace.findUnique({
+      where: { id: workspaceId },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    if (workspace.ownerId !== userId) {
+      throw new ForbiddenException('Only the workspace owner can delete it');
+    }
+
+    // Delete workspace - WorkspaceMember will be deleted in cascade (onDelete: Cascade)
+    // Note: Boards are not yet linked to workspace in schema, so they won't be deleted automatically
+    // This will need to be handled when Board model is updated to include workspaceId
+    await this.prisma.workspace.delete({
+      where: { id: workspaceId },
+    });
+
+    return true;
+  }
 }
 


### PR DESCRIPTION
This pull request adds support for deleting workspaces, including both the resolver and service logic, as well as comprehensive tests for this new functionality. The implementation ensures that only the workspace owner can delete a workspace, and appropriate exceptions are thrown for unauthorized or invalid attempts.

**New workspace deletion feature:**

* Added a `deleteWorkspace` mutation to `WorkspacesResolver`, protected by `AuthGuard`, which delegates deletion to the service and ensures only the owner can perform the operation.
* Implemented `deleteWorkspace` method in `WorkspacesService` to check ownership, handle not found and forbidden cases, and perform the deletion. Cascade deletion of related `WorkspaceMember` records is supported; a note is included for future board deletion handling.

**Testing and mocking improvements:**

* Added tests for the resolver to verify that `deleteWorkspace` correctly calls the service and returns the expected result. [[1]](diffhunk://#diff-9ec433ee69e0efa75ed988993dd962103dbe976b3c2adb89eb2d3742c463b4e6R11) [[2]](diffhunk://#diff-9ec433ee69e0efa75ed988993dd962103dbe976b3c2adb89eb2d3742c463b4e6R68-R77)
* Added comprehensive tests for the service to cover successful deletion, workspace not found, and forbidden deletion attempts.
* Updated service and resolver tests to include mocks for the new `delete` methods.