### PR TITLE
feat: implement removeWorkspaceMember mutation

### DIFF
--- a/backend/src/workspaces/dto/remove-workspace-member.input.ts
+++ b/backend/src/workspaces/dto/remove-workspace-member.input.ts
@@ -1,0 +1,14 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsString } from 'class-validator';
+
+@InputType()
+export class RemoveWorkspaceMemberInput {
+  @Field(() => ID)
+  @IsString()
+  workspaceId!: string;
+
+  @Field(() => ID)
+  @IsString()
+  userId!: string;
+}
+

--- a/backend/src/workspaces/workspaces.resolver.spec.ts
+++ b/backend/src/workspaces/workspaces.resolver.spec.ts
@@ -10,6 +10,7 @@ describe('WorkspacesResolver', () => {
     updateWorkspace: jest.fn(),
     deleteWorkspace: jest.fn(),
     addWorkspaceMember: jest.fn(),
+    removeWorkspaceMember: jest.fn(),
   } as unknown as WorkspacesService;
   const resolver = new WorkspacesResolver(workspacesService);
 
@@ -95,6 +96,21 @@ describe('WorkspacesResolver', () => {
       'member@example.com'
     );
     expect(result).toBe(membership);
+  });
+
+  it('removes a workspace member for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { workspaceId: 'workspace-1', userId: 'user-2' };
+    workspacesService.removeWorkspaceMember = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.removeWorkspaceMember(input, user);
+
+    expect(workspacesService.removeWorkspaceMember).toHaveBeenCalledWith(
+      'workspace-1',
+      'user-1',
+      'user-2'
+    );
+    expect(result).toBe(true);
   });
 });
 

--- a/backend/src/workspaces/workspaces.resolver.ts
+++ b/backend/src/workspaces/workspaces.resolver.ts
@@ -3,6 +3,7 @@ import { User } from '@prisma/client';
 import { AuthGuard } from '../common/guards/gql-auth.decorator';
 import { AddWorkspaceMemberInput } from './dto/add-workspace-member.input';
 import { CreateWorkspaceInput } from './dto/create-workspace.input';
+import { RemoveWorkspaceMemberInput } from './dto/remove-workspace-member.input';
 import { UpdateWorkspaceInput } from './dto/update-workspace.input';
 import { WorkspaceMemberModel } from './models/workspace-member.model';
 import { WorkspaceModel } from './models/workspace.model';
@@ -56,6 +57,15 @@ export class WorkspacesResolver {
     @Context('user') user: User
   ) {
     return this.workspacesService.addWorkspaceMember(input.workspaceId, user.id, input.email);
+  }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async removeWorkspaceMember(
+    @Args('input', { type: () => RemoveWorkspaceMemberInput }) input: RemoveWorkspaceMemberInput,
+    @Context('user') user: User
+  ) {
+    return this.workspacesService.removeWorkspaceMember(input.workspaceId, user.id, input.userId);
   }
 }
 

--- a/backend/src/workspaces/workspaces.service.spec.ts
+++ b/backend/src/workspaces/workspaces.service.spec.ts
@@ -15,6 +15,8 @@ describe('WorkspacesService', () => {
       findMany: jest.fn(),
       findUnique: jest.fn(),
       create: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
     },
     user: {
       findUnique: jest.fn(),
@@ -336,6 +338,154 @@ describe('WorkspacesService', () => {
         service.addWorkspaceMember('workspace-1', 'user-1', 'member@example.com')
       ).rejects.toThrow(ForbiddenException);
       expect(prisma.workspaceMember.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeWorkspaceMember', () => {
+    it('removes a member when owner removes them', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-1',
+      };
+      const memberToRemove = {
+        userId: 'user-2',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.MEMBER,
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(memberToRemove);
+      prisma.workspaceMember.delete = jest.fn().mockResolvedValue(memberToRemove);
+
+      const result = await service.removeWorkspaceMember('workspace-1', 'user-1', 'user-2');
+
+      expect(prisma.workspace.findUnique).toHaveBeenCalledWith({
+        where: { id: 'workspace-1' },
+      });
+      expect(prisma.workspaceMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(prisma.workspaceMember.delete).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('removes an owner when there are multiple owners', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-1',
+      };
+      const ownerToRemove = {
+        userId: 'user-2',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(ownerToRemove);
+      prisma.workspaceMember.count = jest.fn().mockResolvedValue(2);
+      prisma.workspaceMember.delete = jest.fn().mockResolvedValue(ownerToRemove);
+
+      const result = await service.removeWorkspaceMember('workspace-1', 'user-1', 'user-2');
+
+      expect(prisma.workspace.findUnique).toHaveBeenCalledWith({
+        where: { id: 'workspace-1' },
+      });
+      expect(prisma.workspaceMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(prisma.workspaceMember.count).toHaveBeenCalledWith({
+        where: {
+          workspaceId: 'workspace-1',
+          role: WorkspaceRole.OWNER,
+        },
+      });
+      expect(prisma.workspaceMember.delete).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when workspace does not exist', async () => {
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        service.removeWorkspaceMember('workspace-1', 'user-1', 'user-2')
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+      expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not owner', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-2',
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+
+      await expect(
+        service.removeWorkspaceMember('workspace-1', 'user-1', 'user-3')
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+      expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when user is not a member', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-1',
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        service.removeWorkspaceMember('workspace-1', 'user-1', 'user-2')
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when trying to remove the last owner', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-1',
+      };
+      const ownerToRemove = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(ownerToRemove);
+      prisma.workspaceMember.count = jest.fn().mockResolvedValue(1);
+
+      await expect(
+        service.removeWorkspaceMember('workspace-1', 'user-1', 'user-1')
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/workspaces/workspaces.service.ts
+++ b/backend/src/workspaces/workspaces.service.ts
@@ -161,5 +161,57 @@ export class WorkspacesService {
       },
     });
   }
+
+  async removeWorkspaceMember(workspaceId: string, ownerId: string, userIdToRemove: string) {
+    const workspace = await this.prisma.workspace.findUnique({
+      where: { id: workspaceId },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    if (workspace.ownerId !== ownerId) {
+      throw new ForbiddenException('Only the workspace owner can remove members');
+    }
+
+    const memberToRemove = await this.prisma.workspaceMember.findUnique({
+      where: {
+        userId_workspaceId: {
+          userId: userIdToRemove,
+          workspaceId,
+        },
+      },
+    });
+
+    if (!memberToRemove) {
+      throw new NotFoundException('User is not a member of this workspace');
+    }
+
+    // Check if this is the last OWNER
+    if (memberToRemove.role === WorkspaceRole.OWNER) {
+      const ownerCount = await this.prisma.workspaceMember.count({
+        where: {
+          workspaceId,
+          role: WorkspaceRole.OWNER,
+        },
+      });
+
+      if (ownerCount <= 1) {
+        throw new ForbiddenException('Cannot remove the last owner of the workspace');
+      }
+    }
+
+    await this.prisma.workspaceMember.delete({
+      where: {
+        userId_workspaceId: {
+          userId: userIdToRemove,
+          workspaceId,
+        },
+      },
+    });
+
+    return true;
+  }
 }
 


### PR DESCRIPTION
- Add RemoveWorkspaceMemberInput DTO
- Implement removeWorkspaceMember in WorkspacesService (owner only)
- Prevent removal of last OWNER
- Add comprehensive unit tests for service and resolver
This pull request adds support for removing members from a workspace, including robust validation and error handling to ensure only authorized users can perform the action and that the last owner cannot be removed. The changes include updates to the GraphQL API, service layer, and comprehensive tests for various scenarios.

### Workspace Member Removal Feature

* Added a new input type `RemoveWorkspaceMemberInput` to support member removal via GraphQL mutations.
* Implemented the `removeWorkspaceMember` mutation in `WorkspacesResolver`, allowing workspace owners to remove members.

### Service Layer Logic

* Added the `removeWorkspaceMember` method to `WorkspacesService`, which checks workspace existence, ownership, membership, and prevents removal of the last owner.

### Testing

* Added unit tests for `removeWorkspaceMember` covering successful removal, error cases (not found, not owner, not a member, last owner), and multiple owners scenario.
* Updated resolver and service tests to mock new Prisma methods and the service method for member removal. [[1]](diffhunk://#diff-9ec433ee69e0efa75ed988993dd962103dbe976b3c2adb89eb2d3742c463b4e6R100-R114) [[2]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R18-R19) [[3]](diffhunk://#diff-9ec433ee69e0efa75ed988993dd962103dbe976b3c2adb89eb2d3742c463b4e6R13)