### PR TITLE
feat: implement createBoard mutation

### DIFF
--- a/backend/prisma/migrations/20260202180737_add_workspace_to_board/migration.sql
+++ b/backend/prisma/migrations/20260202180737_add_workspace_to_board/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `workspaceId` to the `Board` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Board" ADD COLUMN     "workspaceId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Board" ADD CONSTRAINT "Board_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,6 +28,8 @@ model Board {
   background  String   @default("#0079bf")
   ownerId     String
   owner       User     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  workspaceId String
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
@@ -43,6 +45,7 @@ model Workspace {
   ownerId   String
   owner     User     @relation("WorkspaceOwner", fields: [ownerId], references: [id], onDelete: Cascade)
   members   WorkspaceMember[]
+  boards    Board[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthContextService } from './auth/auth.context';
 import { validateEnv } from './config/env.validation';
 import { WorkspacesModule } from './workspaces/workspaces.module';
+import { BoardsModule } from './boards/boards.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { WorkspacesModule } from './workspaces/workspaces.module';
     PrismaModule,
     AuthModule,
     WorkspacesModule,
+    BoardsModule,
     HealthModule,
   ],
 })

--- a/backend/src/boards/boards.module.ts
+++ b/backend/src/boards/boards.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { BoardsResolver } from './boards.resolver';
+import { BoardsService } from './boards.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  providers: [BoardsService, BoardsResolver],
+  exports: [BoardsService],
+})
+export class BoardsModule {}
+

--- a/backend/src/boards/boards.resolver.spec.ts
+++ b/backend/src/boards/boards.resolver.spec.ts
@@ -1,0 +1,32 @@
+import { User } from '@prisma/client';
+import { BoardsResolver } from './boards.resolver';
+import { BoardsService } from './boards.service';
+
+describe('BoardsResolver', () => {
+  const boardsService = {
+    createBoard: jest.fn(),
+  } as unknown as BoardsService;
+  const resolver = new BoardsResolver(boardsService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a board for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { workspaceId: 'workspace-1', title: 'My Board' };
+    const board = {
+      id: 'board-1',
+      title: 'My Board',
+      ownerId: 'user-1',
+      workspaceId: 'workspace-1',
+    };
+    boardsService.createBoard = jest.fn().mockResolvedValue(board);
+
+    const result = await resolver.createBoard(input, user);
+
+    expect(boardsService.createBoard).toHaveBeenCalledWith('workspace-1', 'My Board', 'user-1');
+    expect(result).toBe(board);
+  });
+});
+

--- a/backend/src/boards/boards.resolver.ts
+++ b/backend/src/boards/boards.resolver.ts
@@ -1,0 +1,21 @@
+import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
+import { User } from '@prisma/client';
+import { AuthGuard } from '../common/guards/gql-auth.decorator';
+import { CreateBoardInput } from './dto/create-board.input';
+import { BoardModel } from './models/board.model';
+import { BoardsService } from './boards.service';
+
+@Resolver(() => BoardModel)
+export class BoardsResolver {
+  constructor(private readonly boardsService: BoardsService) {}
+
+  @Mutation(() => BoardModel)
+  @AuthGuard()
+  async createBoard(
+    @Args('input', { type: () => CreateBoardInput }) input: CreateBoardInput,
+    @Context('user') user: User
+  ) {
+    return this.boardsService.createBoard(input.workspaceId, input.title, user.id);
+  }
+}
+

--- a/backend/src/boards/boards.service.spec.ts
+++ b/backend/src/boards/boards.service.spec.ts
@@ -1,0 +1,147 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { BoardsService } from './boards.service';
+
+describe('BoardsService', () => {
+  const prisma = {
+    workspace: {
+      findUnique: jest.fn(),
+    },
+    workspaceMember: {
+      findUnique: jest.fn(),
+    },
+    board: {
+      create: jest.fn(),
+    },
+  } as unknown as PrismaService;
+  const service = new BoardsService(prisma);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createBoard', () => {
+    it('creates a board when user is a workspace member', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-1',
+      };
+      const membership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: 'MEMBER' as const,
+      };
+      const board = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        owner: { id: 'user-1', username: 'user1', email: 'user1@example.com' },
+        workspace,
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(membership);
+      prisma.board.create = jest.fn().mockResolvedValue(board);
+
+      const result = await service.createBoard('workspace-1', 'My Board', 'user-1');
+
+      expect(prisma.workspace.findUnique).toHaveBeenCalledWith({
+        where: { id: 'workspace-1' },
+      });
+      expect(prisma.workspaceMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(prisma.board.create).toHaveBeenCalledWith({
+        data: {
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          ownerId: 'user-1', // board owner = creator
+        },
+        include: {
+          owner: true,
+          workspace: true,
+        },
+      });
+      expect(result).toBe(board);
+    });
+
+    it('throws NotFoundException when workspace does not exist', async () => {
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.createBoard('workspace-1', 'My Board', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+      expect(prisma.board.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-2',
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.createBoard('workspace-1', 'My Board', 'user-1')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.board.create).not.toHaveBeenCalled();
+    });
+
+    it('creates board with ownerId equal to creator userId', async () => {
+      const workspace = {
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-2',
+      };
+      const membership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: 'MEMBER' as const,
+      };
+      const board = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1', // creator is the owner
+        workspaceId: 'workspace-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        owner: { id: 'user-1', username: 'user1', email: 'user1@example.com' },
+        workspace,
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(membership);
+      prisma.board.create = jest.fn().mockResolvedValue(board);
+
+      const result = await service.createBoard('workspace-1', 'My Board', 'user-1');
+
+      expect(prisma.board.create).toHaveBeenCalledWith({
+        data: {
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          ownerId: 'user-1', // board owner = creator
+        },
+        include: {
+          owner: true,
+          workspace: true,
+        },
+      });
+      expect(result.ownerId).toBe('user-1'); // Verify owner is creator
+    });
+  });
+});
+

--- a/backend/src/boards/boards.service.ts
+++ b/backend/src/boards/boards.service.ts
@@ -1,0 +1,46 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class BoardsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createBoard(workspaceId: string, title: string, userId: string) {
+    // Check if workspace exists
+    const workspace = await this.prisma.workspace.findUnique({
+      where: { id: workspaceId },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    // Check if user is a member of the workspace
+    const membership = await this.prisma.workspaceMember.findUnique({
+      where: {
+        userId_workspaceId: {
+          userId,
+          workspaceId,
+        },
+      },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('User is not a member of this workspace');
+    }
+
+    // Create board with owner = creator (userId)
+    return this.prisma.board.create({
+      data: {
+        title,
+        workspaceId,
+        ownerId: userId, // board owner = creator
+      },
+      include: {
+        owner: true,
+        workspace: true,
+      },
+    });
+  }
+}
+

--- a/backend/src/boards/dto/create-board.input.ts
+++ b/backend/src/boards/dto/create-board.input.ts
@@ -1,0 +1,15 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class CreateBoardInput {
+  @Field(() => ID)
+  @IsString()
+  workspaceId!: string;
+
+  @Field()
+  @IsString()
+  @MinLength(1)
+  title!: string;
+}
+

--- a/backend/src/boards/models/board.model.ts
+++ b/backend/src/boards/models/board.model.ts
@@ -17,6 +17,9 @@ export class BoardModel {
   @Field()
   ownerId!: string;
 
+  @Field(() => ID)
+  workspaceId!: string;
+
   @Field()
   createdAt!: Date;
 

--- a/backend/src/workspaces/workspaces.service.ts
+++ b/backend/src/workspaces/workspaces.service.ts
@@ -105,9 +105,7 @@ export class WorkspacesService {
       throw new ForbiddenException('Only the workspace owner can delete it');
     }
 
-    // Delete workspace - WorkspaceMember will be deleted in cascade (onDelete: Cascade)
-    // Note: Boards are not yet linked to workspace in schema, so they won't be deleted automatically
-    // This will need to be handled when Board model is updated to include workspaceId
+    // Delete workspace - WorkspaceMember and Boards will be deleted in cascade (onDelete: Cascade)
     await this.prisma.workspace.delete({
       where: { id: workspaceId },
     });


### PR DESCRIPTION

This pull request introduces support for associating boards with workspaces in the backend. It updates the database schema to add a required `workspaceId` field to the `Board` model, creates the necessary service and resolver logic to allow users to create boards within a workspace (with appropriate access control), and adds tests for the new functionality. It also ensures that deleting a workspace cascades to its boards.

**Database schema updates:**

- Added a required `workspaceId` field to the `Board` table, established a foreign key constraint linking boards to workspaces, and updated the Prisma schema to reflect this relationship. Boards are now properly associated with a workspace, and deleting a workspace will cascade to its boards. [[1]](diffhunk://#diff-b959e4f15d8450371eb1673095528d95e98a0aef8bbf8db88e69cf584565068bR1-R11) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR31-R32) [[3]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR48) [[4]](diffhunk://#diff-2cc0ece44c713873ef8faaabbb96a57483078a41893e4f77abd40e71044427ddL108-R108)

**Backend service and resolver logic:**

- Implemented `BoardsService` with a `createBoard` method that validates workspace existence, checks that the user is a workspace member, and creates the board with the creator as owner.
- Added `BoardsResolver` with a `createBoard` mutation, using a DTO for input validation and enforcing authentication. [[1]](diffhunk://#diff-f6b5b942743a2af108065b80b815b06d766c8129969b303288698531582add8cR1-R21) [[2]](diffhunk://#diff-14b91624c2cb9ccc57e32e2fa838556d3da7301d5c2162fe6f3d42b864d98435R1-R15)
- Registered the new `BoardsModule` in the application module and created the module definition. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R12) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R32) [[3]](diffhunk://#diff-2e7553d8249d90a2cc7563316ac9e4f38c88dc2273d079314ffb4b7a38114a8eR1-R13)

**Testing:**

- Added tests for `BoardsService` to verify board creation, membership checks, and error handling.
- Added tests for `BoardsResolver` to ensure mutation behaves as expected.

**GraphQL model updates:**

- Updated the `BoardModel` GraphQL type to include the new `workspaceId` field.