### PR TITLE
feat: implement leaveWorkspace mutation with last owner protection

### DIFF
--- a/backend/src/workspaces/dto/leave-workspace.input.ts
+++ b/backend/src/workspaces/dto/leave-workspace.input.ts
@@ -1,0 +1,10 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsString } from 'class-validator';
+
+@InputType()
+export class LeaveWorkspaceInput {
+  @Field(() => ID)
+  @IsString()
+  workspaceId!: string;
+}
+

--- a/backend/src/workspaces/workspaces.resolver.spec.ts
+++ b/backend/src/workspaces/workspaces.resolver.spec.ts
@@ -11,6 +11,7 @@ describe('WorkspacesResolver', () => {
     deleteWorkspace: jest.fn(),
     addWorkspaceMember: jest.fn(),
     removeWorkspaceMember: jest.fn(),
+    leaveWorkspace: jest.fn(),
   } as unknown as WorkspacesService;
   const resolver = new WorkspacesResolver(workspacesService);
 
@@ -110,6 +111,17 @@ describe('WorkspacesResolver', () => {
       'user-1',
       'user-2'
     );
+    expect(result).toBe(true);
+  });
+
+  it('allows user to leave a workspace', async () => {
+    const user = { id: 'user-2' } as User;
+    const input = { workspaceId: 'workspace-1' };
+    workspacesService.leaveWorkspace = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.leaveWorkspace(input, user);
+
+    expect(workspacesService.leaveWorkspace).toHaveBeenCalledWith('workspace-1', 'user-2');
     expect(result).toBe(true);
   });
 });

--- a/backend/src/workspaces/workspaces.resolver.ts
+++ b/backend/src/workspaces/workspaces.resolver.ts
@@ -3,6 +3,7 @@ import { User } from '@prisma/client';
 import { AuthGuard } from '../common/guards/gql-auth.decorator';
 import { AddWorkspaceMemberInput } from './dto/add-workspace-member.input';
 import { CreateWorkspaceInput } from './dto/create-workspace.input';
+import { LeaveWorkspaceInput } from './dto/leave-workspace.input';
 import { RemoveWorkspaceMemberInput } from './dto/remove-workspace-member.input';
 import { UpdateWorkspaceInput } from './dto/update-workspace.input';
 import { WorkspaceMemberModel } from './models/workspace-member.model';
@@ -66,6 +67,15 @@ export class WorkspacesResolver {
     @Context('user') user: User
   ) {
     return this.workspacesService.removeWorkspaceMember(input.workspaceId, user.id, input.userId);
+  }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async leaveWorkspace(
+    @Args('input', { type: () => LeaveWorkspaceInput }) input: LeaveWorkspaceInput,
+    @Context('user') user: User
+  ) {
+    return this.workspacesService.leaveWorkspace(input.workspaceId, user.id);
   }
 }
 

--- a/backend/src/workspaces/workspaces.service.spec.ts
+++ b/backend/src/workspaces/workspaces.service.spec.ts
@@ -488,5 +488,98 @@ describe('WorkspacesService', () => {
       expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
     });
   });
+
+  describe('leaveWorkspace', () => {
+    it('allows a member to leave the workspace', async () => {
+      const membership = {
+        userId: 'user-2',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.MEMBER,
+      };
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(membership);
+      prisma.workspaceMember.delete = jest.fn().mockResolvedValue(membership);
+
+      const result = await service.leaveWorkspace('workspace-1', 'user-2');
+
+      expect(prisma.workspaceMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(prisma.workspaceMember.delete).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('allows an owner to leave when there are multiple owners', async () => {
+      const membership = {
+        userId: 'user-2',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(membership);
+      prisma.workspaceMember.count = jest.fn().mockResolvedValue(2);
+      prisma.workspaceMember.delete = jest.fn().mockResolvedValue(membership);
+
+      const result = await service.leaveWorkspace('workspace-1', 'user-2');
+
+      expect(prisma.workspaceMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(prisma.workspaceMember.count).toHaveBeenCalledWith({
+        where: {
+          workspaceId: 'workspace-1',
+          role: WorkspaceRole.OWNER,
+        },
+      });
+      expect(prisma.workspaceMember.delete).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-2',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when user is not a member', async () => {
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.leaveWorkspace('workspace-1', 'user-2')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when trying to leave as the last owner', async () => {
+      const membership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(membership);
+      prisma.workspaceMember.count = jest.fn().mockResolvedValue(1);
+
+      await expect(service.leaveWorkspace('workspace-1', 'user-1')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
+    });
+  });
 });
 

--- a/backend/src/workspaces/workspaces.service.ts
+++ b/backend/src/workspaces/workspaces.service.ts
@@ -211,5 +211,45 @@ export class WorkspacesService {
 
     return true;
   }
+
+  async leaveWorkspace(workspaceId: string, userId: string) {
+    const membership = await this.prisma.workspaceMember.findUnique({
+      where: {
+        userId_workspaceId: {
+          userId,
+          workspaceId,
+        },
+      },
+    });
+
+    if (!membership) {
+      throw new NotFoundException('User is not a member of this workspace');
+    }
+
+    // Check if this is the last OWNER
+    if (membership.role === WorkspaceRole.OWNER) {
+      const ownerCount = await this.prisma.workspaceMember.count({
+        where: {
+          workspaceId,
+          role: WorkspaceRole.OWNER,
+        },
+      });
+
+      if (ownerCount <= 1) {
+        throw new ForbiddenException('Cannot leave workspace as the last owner');
+      }
+    }
+
+    await this.prisma.workspaceMember.delete({
+      where: {
+        userId_workspaceId: {
+          userId,
+          workspaceId,
+        },
+      },
+    });
+
+    return true;
+  }
 }
 


### PR DESCRIPTION
This pull request introduces a new feature that allows users to leave a workspace. The implementation includes input validation, resolver and service logic, and comprehensive tests to ensure correct behavior, including handling edge cases for workspace owners.

### New feature: User can leave a workspace

* Added `LeaveWorkspaceInput` DTO to validate and structure the input for leaving a workspace.
* Implemented the `leaveWorkspace` mutation in `WorkspacesResolver`, enabling authenticated users to leave a workspace. [[1]](diffhunk://#diff-a24a2862ec264e62386650006962dcfe621f730cf6696e496a4bc3a078f4eff0R6) [[2]](diffhunk://#diff-a24a2862ec264e62386650006962dcfe621f730cf6696e496a4bc3a078f4eff0R71-R79)

### Service logic and edge case handling

* Added `leaveWorkspace` method to `WorkspacesService` to handle membership removal, including checks to prevent the last owner from leaving and to ensure the user is a member.

### Testing

* Added unit tests for the resolver and service to cover successful leave, owner leave with multiple owners, error when not a member, and error when trying to leave as the last owner. [[1]](diffhunk://#diff-9ec433ee69e0efa75ed988993dd962103dbe976b3c2adb89eb2d3742c463b4e6R14) [[2]](diffhunk://#diff-9ec433ee69e0efa75ed988993dd962103dbe976b3c2adb89eb2d3742c463b4e6R116-R126) [[3]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R491-R583)