### PR TITLE
Add workspace access helper methods and tests

### DIFF
--- a/backend/src/workspaces/workspaces.service.spec.ts
+++ b/backend/src/workspaces/workspaces.service.spec.ts
@@ -84,6 +84,11 @@ describe('WorkspacesService', () => {
   });
 
   it('rejects access when user is not a workspace member', async () => {
+    prisma.workspace.findUnique = jest.fn().mockResolvedValue({
+      id: 'workspace-1',
+      name: 'Acme',
+      ownerId: 'owner-1',
+    });
     prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(null);
 
     await expect(service.getWorkspace('user-1', 'workspace-1')).rejects.toBeInstanceOf(
@@ -93,8 +98,8 @@ describe('WorkspacesService', () => {
 
   it('returns workspace details when user is a member', async () => {
     const workspace = { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' };
-    prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({ userId: 'user-1' });
     prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+    prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({ userId: 'user-1' });
     prisma.workspaceMember.findMany = jest
       .fn()
       .mockResolvedValue([{ userId: 'user-1', workspaceId: 'workspace-1' }]);
@@ -120,6 +125,87 @@ describe('WorkspacesService', () => {
     });
   });
 
+  describe('requireWorkspaceAccess', () => {
+    it('returns workspace and membership when user is a member', async () => {
+      const workspace = { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' };
+      const membership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(membership);
+
+      const result = await service.requireWorkspaceAccess('workspace-1', 'user-1');
+
+      expect(result).toEqual({ workspace, membership });
+    });
+
+    it('throws NotFoundException when workspace does not exist', async () => {
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.requireWorkspaceAccess('workspace-1', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a member', async () => {
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue({
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'owner-1',
+      });
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.requireWorkspaceAccess('workspace-1', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+  });
+
+  describe('requireWorkspaceOwner', () => {
+    it('returns workspace and membership when user is an owner', async () => {
+      const workspace = { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' };
+      const membership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(membership);
+
+      const result = await service.requireWorkspaceOwner('workspace-1', 'user-1');
+
+      expect(result).toEqual({ workspace, membership });
+    });
+
+    it('throws ForbiddenException when user is not an owner', async () => {
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue({
+        id: 'workspace-1',
+        name: 'Acme',
+        ownerId: 'user-1',
+      });
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-2',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.MEMBER,
+      });
+
+      await expect(service.requireWorkspaceOwner('workspace-1', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it('throws NotFoundException when workspace does not exist', async () => {
+      prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.requireWorkspaceOwner('workspace-1', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
   describe('updateWorkspace', () => {
     it('updates workspace name when user is owner', async () => {
       const workspace = {
@@ -127,6 +213,11 @@ describe('WorkspacesService', () => {
         name: 'Acme',
         ownerId: 'user-1',
       };
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      });
       const updatedWorkspace = {
         ...workspace,
         name: 'Updated Acme',
@@ -152,6 +243,7 @@ describe('WorkspacesService', () => {
 
     it('throws NotFoundException when workspace does not exist', async () => {
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.workspaceMember.findUnique = jest.fn();
 
       await expect(service.updateWorkspace('workspace-1', 'user-1', 'New Name')).rejects.toThrow(
         NotFoundException
@@ -166,6 +258,11 @@ describe('WorkspacesService', () => {
         ownerId: 'user-2',
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.MEMBER,
+      });
 
       await expect(service.updateWorkspace('workspace-1', 'user-1', 'New Name')).rejects.toThrow(
         ForbiddenException
@@ -182,6 +279,11 @@ describe('WorkspacesService', () => {
         ownerId: 'user-1',
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      });
       prisma.workspace.delete = jest.fn().mockResolvedValue(workspace);
 
       const result = await service.deleteWorkspace('workspace-1', 'user-1');
@@ -197,6 +299,7 @@ describe('WorkspacesService', () => {
 
     it('throws NotFoundException when workspace does not exist', async () => {
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.workspaceMember.findUnique = jest.fn();
 
       await expect(service.deleteWorkspace('workspace-1', 'user-1')).rejects.toThrow(
         NotFoundException
@@ -211,6 +314,11 @@ describe('WorkspacesService', () => {
         ownerId: 'user-2',
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.MEMBER,
+      });
 
       await expect(service.deleteWorkspace('workspace-1', 'user-1')).rejects.toThrow(
         ForbiddenException
@@ -240,7 +348,14 @@ describe('WorkspacesService', () => {
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
       prisma.user.findUnique = jest.fn().mockResolvedValue(user);
-      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.workspaceMember.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce({
+          userId: 'user-1',
+          workspaceId: 'workspace-1',
+          role: WorkspaceRole.OWNER,
+        })
+        .mockResolvedValueOnce(null);
       prisma.workspaceMember.create = jest.fn().mockResolvedValue(membership);
 
       const result = await service.addWorkspaceMember('workspace-1', 'user-1', 'member@example.com');
@@ -290,6 +405,11 @@ describe('WorkspacesService', () => {
         ownerId: 'user-2',
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.MEMBER,
+      });
 
       await expect(
         service.addWorkspaceMember('workspace-1', 'user-1', 'member@example.com')
@@ -305,12 +425,24 @@ describe('WorkspacesService', () => {
         ownerId: 'user-1',
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      });
       prisma.user.findUnique = jest.fn().mockResolvedValue(null);
 
       await expect(
         service.addWorkspaceMember('workspace-1', 'user-1', 'notfound@example.com')
       ).rejects.toThrow(NotFoundException);
-      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+      expect(prisma.workspaceMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
       expect(prisma.workspaceMember.create).not.toHaveBeenCalled();
     });
 
@@ -332,7 +464,14 @@ describe('WorkspacesService', () => {
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
       prisma.user.findUnique = jest.fn().mockResolvedValue(user);
-      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(existingMember);
+      prisma.workspaceMember.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce({
+          userId: 'user-1',
+          workspaceId: 'workspace-1',
+          role: WorkspaceRole.OWNER,
+        })
+        .mockResolvedValueOnce(existingMember);
 
       await expect(
         service.addWorkspaceMember('workspace-1', 'user-1', 'member@example.com')
@@ -348,13 +487,21 @@ describe('WorkspacesService', () => {
         name: 'Acme',
         ownerId: 'user-1',
       };
+      const ownerMembership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
       const memberToRemove = {
         userId: 'user-2',
         workspaceId: 'workspace-1',
         role: WorkspaceRole.MEMBER,
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
-      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(memberToRemove);
+      prisma.workspaceMember.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(ownerMembership)
+        .mockResolvedValueOnce(memberToRemove);
       prisma.workspaceMember.delete = jest.fn().mockResolvedValue(memberToRemove);
 
       const result = await service.removeWorkspaceMember('workspace-1', 'user-1', 'user-2');
@@ -387,13 +534,21 @@ describe('WorkspacesService', () => {
         name: 'Acme',
         ownerId: 'user-1',
       };
+      const ownerMembership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
       const ownerToRemove = {
         userId: 'user-2',
         workspaceId: 'workspace-1',
         role: WorkspaceRole.OWNER,
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
-      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(ownerToRemove);
+      prisma.workspaceMember.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(ownerMembership)
+        .mockResolvedValueOnce(ownerToRemove);
       prisma.workspaceMember.count = jest.fn().mockResolvedValue(2);
       prisma.workspaceMember.delete = jest.fn().mockResolvedValue(ownerToRemove);
 
@@ -429,6 +584,7 @@ describe('WorkspacesService', () => {
 
     it('throws NotFoundException when workspace does not exist', async () => {
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.workspaceMember.findUnique = jest.fn();
 
       await expect(
         service.removeWorkspaceMember('workspace-1', 'user-1', 'user-2')
@@ -444,11 +600,23 @@ describe('WorkspacesService', () => {
         ownerId: 'user-2',
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
+      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue({
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.MEMBER,
+      });
 
       await expect(
         service.removeWorkspaceMember('workspace-1', 'user-1', 'user-3')
       ).rejects.toThrow(ForbiddenException);
-      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+      expect(prisma.workspaceMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_workspaceId: {
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+          },
+        },
+      });
       expect(prisma.workspaceMember.delete).not.toHaveBeenCalled();
     });
 
@@ -458,8 +626,16 @@ describe('WorkspacesService', () => {
         name: 'Acme',
         ownerId: 'user-1',
       };
+      const ownerMembership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
-      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.workspaceMember.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(ownerMembership)
+        .mockResolvedValueOnce(null);
 
       await expect(
         service.removeWorkspaceMember('workspace-1', 'user-1', 'user-2')
@@ -473,13 +649,21 @@ describe('WorkspacesService', () => {
         name: 'Acme',
         ownerId: 'user-1',
       };
+      const ownerMembership = {
+        userId: 'user-1',
+        workspaceId: 'workspace-1',
+        role: WorkspaceRole.OWNER,
+      };
       const ownerToRemove = {
         userId: 'user-1',
         workspaceId: 'workspace-1',
         role: WorkspaceRole.OWNER,
       };
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(workspace);
-      prisma.workspaceMember.findUnique = jest.fn().mockResolvedValue(ownerToRemove);
+      prisma.workspaceMember.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(ownerMembership)
+        .mockResolvedValueOnce(ownerToRemove);
       prisma.workspaceMember.count = jest.fn().mockResolvedValue(1);
 
       await expect(

--- a/backend/src/workspaces/workspaces.service.ts
+++ b/backend/src/workspaces/workspaces.service.ts
@@ -1,5 +1,5 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { WorkspaceRole } from '@prisma/client';
+import { Workspace, WorkspaceMember, WorkspaceRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -23,6 +23,47 @@ export class WorkspacesService {
       },
     });
   }
+
+  private async requireWorkspace(workspaceId: string): Promise<Workspace> {
+    const workspace = await this.prisma.workspace.findUnique({
+      where: { id: workspaceId },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    return workspace;
+  }
+
+  async requireWorkspaceAccess(
+    workspaceId: string,
+    userId: string
+  ): Promise<{ workspace: Workspace; membership: WorkspaceMember }> {
+    const workspace = await this.requireWorkspace(workspaceId);
+    const membership = await this.prisma.workspaceMember.findUnique({
+      where: { userId_workspaceId: { userId, workspaceId } },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    return { workspace, membership };
+  }
+
+  async requireWorkspaceOwner(
+    workspaceId: string,
+    userId: string
+  ): Promise<{ workspace: Workspace; membership: WorkspaceMember }> {
+    const { workspace, membership } = await this.requireWorkspaceAccess(workspaceId, userId);
+
+    if (membership.role !== WorkspaceRole.OWNER) {
+      throw new ForbiddenException('Only a workspace owner can perform this action');
+    }
+
+    return { workspace, membership };
+  }
   myWorkspaces(userId: string) {
     return this.prisma.workspaceMember.findMany({
       where: { userId },
@@ -42,12 +83,7 @@ export class WorkspacesService {
   }
 
   async getWorkspace(userId: string, workspaceId: string) {
-    const membership = await this.prisma.workspaceMember.findUnique({
-      where: { userId_workspaceId: { userId, workspaceId } },
-    });
-    if (!membership) {
-      throw new ForbiddenException('Access denied');
-    }
+    await this.requireWorkspaceAccess(workspaceId, userId);
 
     const workspace = await this.prisma.workspace.findUnique({
       where: { id: workspaceId },
@@ -71,17 +107,7 @@ export class WorkspacesService {
   }
 
   async updateWorkspace(workspaceId: string, userId: string, name: string) {
-    const workspace = await this.prisma.workspace.findUnique({
-      where: { id: workspaceId },
-    });
-
-    if (!workspace) {
-      throw new NotFoundException('Workspace not found');
-    }
-
-    if (workspace.ownerId !== userId) {
-      throw new ForbiddenException('Only the workspace owner can update it');
-    }
+    await this.requireWorkspaceOwner(workspaceId, userId);
 
     return this.prisma.workspace.update({
       where: { id: workspaceId },
@@ -93,17 +119,7 @@ export class WorkspacesService {
   }
 
   async deleteWorkspace(workspaceId: string, userId: string) {
-    const workspace = await this.prisma.workspace.findUnique({
-      where: { id: workspaceId },
-    });
-
-    if (!workspace) {
-      throw new NotFoundException('Workspace not found');
-    }
-
-    if (workspace.ownerId !== userId) {
-      throw new ForbiddenException('Only the workspace owner can delete it');
-    }
+    await this.requireWorkspaceOwner(workspaceId, userId);
 
     // Delete workspace - WorkspaceMember and Boards will be deleted in cascade (onDelete: Cascade)
     await this.prisma.workspace.delete({
@@ -114,17 +130,7 @@ export class WorkspacesService {
   }
 
   async addWorkspaceMember(workspaceId: string, ownerId: string, email: string) {
-    const workspace = await this.prisma.workspace.findUnique({
-      where: { id: workspaceId },
-    });
-
-    if (!workspace) {
-      throw new NotFoundException('Workspace not found');
-    }
-
-    if (workspace.ownerId !== ownerId) {
-      throw new ForbiddenException('Only the workspace owner can add members');
-    }
+    await this.requireWorkspaceOwner(workspaceId, ownerId);
 
     const user = await this.prisma.user.findUnique({
       where: { email },
@@ -161,17 +167,7 @@ export class WorkspacesService {
   }
 
   async removeWorkspaceMember(workspaceId: string, ownerId: string, userIdToRemove: string) {
-    const workspace = await this.prisma.workspace.findUnique({
-      where: { id: workspaceId },
-    });
-
-    if (!workspace) {
-      throw new NotFoundException('Workspace not found');
-    }
-
-    if (workspace.ownerId !== ownerId) {
-      throw new ForbiddenException('Only the workspace owner can remove members');
-    }
+    await this.requireWorkspaceOwner(workspaceId, ownerId);
 
     const memberToRemove = await this.prisma.workspaceMember.findUnique({
       where: {


### PR DESCRIPTION
This pull request refactors the `WorkspacesService` to centralize and improve workspace access and ownership checks, and updates the corresponding tests for better coverage and clarity. The main logic for verifying workspace existence, membership, and ownership is now encapsulated in dedicated helper methods, reducing code duplication and ensuring consistent error handling across all service methods.

Key changes include:

**Refactoring and Centralization of Access Control:**

* Introduced `requireWorkspace`, `requireWorkspaceAccess`, and `requireWorkspaceOwner` helper methods in `workspaces.service.ts` to handle workspace existence, membership, and ownership checks in a consistent and reusable way. Service methods like `getWorkspace`, `updateWorkspace`, and `deleteWorkspace` now use these helpers instead of duplicating access logic. [[1]](diffhunk://#diff-2cc0ece44c713873ef8faaabbb96a57483078a41893e4f77abd40e71044427ddR26-R66) [[2]](diffhunk://#diff-2cc0ece44c713873ef8faaabbb96a57483078a41893e4f77abd40e71044427ddL45-R86) [[3]](diffhunk://#diff-2cc0ece44c713873ef8faaabbb96a57483078a41893e4f77abd40e71044427ddL74-R110) [[4]](diffhunk://#diff-2cc0ece44c713873ef8faaabbb96a57483078a41893e4f77abd40e71044427ddL96-R122)

**Test Suite Enhancements:**

* Added comprehensive tests for the new helper methods (`requireWorkspaceAccess` and `requireWorkspaceOwner`), covering successful access, forbidden access, and not found scenarios.
* Updated existing tests to mock the new access control flow, including proper setup of membership and ownership states for various scenarios in workspace update, delete, member add, and remove operations. [[1]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R87-R91) [[2]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898L96-R102) [[3]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R246) [[4]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R261-R265) [[5]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R282-R286) [[6]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R302) [[7]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R317-R321) [[8]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898L243-R358) [[9]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R408-R412) [[10]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R428-R445) [[11]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898L335-R474) [[12]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R490-R504) [[13]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R537-R551) [[14]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R587) [[15]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R603-R619) [[16]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R629-R638) [[17]](diffhunk://#diff-8b3c421daa11d8112930cec6ac610c940fb7fa763950a752e28e89e36d289898R652-R666)

**Consistency and Type Improvements:**

* Updated imports in `workspaces.service.ts` to include relevant Prisma types (`Workspace`, `WorkspaceMember`) for improved type safety.

These changes make the codebase more maintainable, ensure consistent permission checks, and improve test reliability.