### PR TITLE
Enforce workspace requirement for boards

### DIFF
--- a/backend/src/boards/boards.service.spec.ts
+++ b/backend/src/boards/boards.service.spec.ts
@@ -75,6 +75,24 @@ describe('BoardsService', () => {
       expect(result).toBe(board);
     });
 
+    it('throws NotFoundException when workspaceId is empty', async () => {
+      await expect(service.createBoard('', 'My Board', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.workspace.findUnique).not.toHaveBeenCalled();
+      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+      expect(prisma.board.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when workspaceId is whitespace only', async () => {
+      await expect(service.createBoard('   ', 'My Board', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.workspace.findUnique).not.toHaveBeenCalled();
+      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+      expect(prisma.board.create).not.toHaveBeenCalled();
+    });
+
     it('throws NotFoundException when workspace does not exist', async () => {
       prisma.workspace.findUnique = jest.fn().mockResolvedValue(null);
 

--- a/backend/src/boards/boards.service.ts
+++ b/backend/src/boards/boards.service.ts
@@ -6,6 +6,11 @@ export class BoardsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async createBoard(workspaceId: string, title: string, userId: string) {
+    // Validate workspaceId is provided
+    if (!workspaceId || workspaceId.trim() === '') {
+      throw new NotFoundException('Workspace ID is required');
+    }
+
     // Check if workspace exists
     const workspace = await this.prisma.workspace.findUnique({
       where: { id: workspaceId },

--- a/backend/src/boards/dto/create-board.input.ts
+++ b/backend/src/boards/dto/create-board.input.ts
@@ -1,10 +1,11 @@
 import { Field, ID, InputType } from '@nestjs/graphql';
-import { IsString, MinLength } from 'class-validator';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
 
 @InputType()
 export class CreateBoardInput {
   @Field(() => ID)
   @IsString()
+  @IsNotEmpty()
   workspaceId!: string;
 
   @Field()


### PR DESCRIPTION
This pull request improves the validation and error handling for creating boards by ensuring that a valid, non-empty `workspaceId` is provided. It adds stricter input validation at both the DTO and service levels, and introduces new tests to cover these scenarios.

**Validation improvements:**

* Added the `@IsNotEmpty()` validator to the `workspaceId` field in the `CreateBoardInput` DTO to ensure the field is not empty when creating a board (`backend/src/boards/dto/create-board.input.ts`).
* Updated the `createBoard` method in `BoardsService` to explicitly check that `workspaceId` is neither empty nor only whitespace, throwing a `NotFoundException` if invalid (`backend/src/boards/boards.service.ts`).

**Testing enhancements:**

* Added new tests to `BoardsService` to verify that a `NotFoundException` is thrown when `workspaceId` is empty or contains only whitespace, and that no database calls are made in these cases (`backend/src/boards/boards.service.spec.ts`).