### PR TITLE
Add board(id) query with lists and cards

### DIFF
--- a/backend/prisma/migrations/20260202222658_add_list_and_card_models/migration.sql
+++ b/backend/prisma/migrations/20260202222658_add_list_and_card_models/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "List" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "boardId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "List_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Card" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "listId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Card_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "List_boardId_idx" ON "List"("boardId");
+
+-- CreateIndex
+CREATE INDEX "Card_listId_idx" ON "Card"("listId");
+
+-- AddForeignKey
+ALTER TABLE "List" ADD CONSTRAINT "List_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "Board"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Card" ADD CONSTRAINT "Card_listId_fkey" FOREIGN KEY ("listId") REFERENCES "List"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -30,8 +30,35 @@ model Board {
   owner       User     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
   workspaceId String
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  lists       List[]
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+model List {
+  id          String   @id @default(uuid())
+  title       String
+  position    Int      @default(0)
+  boardId     String
+  board       Board    @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  cards       Card[]
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([boardId])
+}
+
+model Card {
+  id          String   @id @default(uuid())
+  title       String
+  description String?
+  position    Int      @default(0)
+  listId      String
+  list        List     @relation(fields: [listId], references: [id], onDelete: Cascade)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([listId])
 }
 
 enum WorkspaceRole {

--- a/backend/src/boards/boards.resolver.spec.ts
+++ b/backend/src/boards/boards.resolver.spec.ts
@@ -5,6 +5,8 @@ import { BoardsService } from './boards.service';
 describe('BoardsResolver', () => {
   const boardsService = {
     createBoard: jest.fn(),
+    workspaceBoards: jest.fn(),
+    board: jest.fn(),
   } as unknown as BoardsService;
   const resolver = new BoardsResolver(boardsService);
 
@@ -51,6 +53,38 @@ describe('BoardsResolver', () => {
 
     expect(boardsService.workspaceBoards).toHaveBeenCalledWith('workspace-1', 'user-1');
     expect(result).toBe(boards);
+  });
+
+  it('returns board with lists and cards for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const board = {
+      id: 'board-1',
+      title: 'My Board',
+      ownerId: 'user-1',
+      workspaceId: 'workspace-1',
+      lists: [
+        {
+          id: 'list-1',
+          title: 'To Do',
+          position: 0,
+          boardId: 'board-1',
+          cards: [
+            {
+              id: 'card-1',
+              title: 'Card 1',
+              position: 0,
+              listId: 'list-1',
+            },
+          ],
+        },
+      ],
+    };
+    boardsService.board = jest.fn().mockResolvedValue(board);
+
+    const result = await resolver.board('board-1', user);
+
+    expect(boardsService.board).toHaveBeenCalledWith('board-1', 'user-1');
+    expect(result).toBe(board);
   });
 });
 

--- a/backend/src/boards/boards.resolver.ts
+++ b/backend/src/boards/boards.resolver.ts
@@ -26,5 +26,11 @@ export class BoardsResolver {
   ) {
     return this.boardsService.workspaceBoards(workspaceId, user.id);
   }
+
+  @Query(() => BoardModel, { nullable: true })
+  @AuthGuard()
+  async board(@Args('id') id: string, @Context('user') user: User) {
+    return this.boardsService.board(id, user.id);
+  }
 }
 

--- a/backend/src/boards/boards.service.spec.ts
+++ b/backend/src/boards/boards.service.spec.ts
@@ -14,6 +14,7 @@ describe('BoardsService', () => {
     board: {
       create: jest.fn(),
       findMany: jest.fn(),
+      findUnique: jest.fn(),
     },
   } as unknown as PrismaService;
   const workspacesService = {
@@ -319,6 +320,190 @@ describe('BoardsService', () => {
         },
       });
       expect(result).toBe(boards);
+    });
+  });
+
+  describe('board', () => {
+    it('returns board with lists and cards when user is a workspace member', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const boardWithLists = {
+        ...boardWithWorkspace,
+        owner: { id: 'user-1', username: 'user1', email: 'user1@example.com' },
+        workspace: boardWithWorkspace.workspace,
+        lists: [
+          {
+            id: 'list-1',
+            title: 'To Do',
+            position: 0,
+            boardId: 'board-1',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            cards: [
+              {
+                id: 'card-1',
+                title: 'Card 1',
+                description: null,
+                position: 0,
+                listId: 'list-1',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+              {
+                id: 'card-2',
+                title: 'Card 2',
+                description: 'Description',
+                position: 1,
+                listId: 'list-1',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            ],
+          },
+          {
+            id: 'list-2',
+            title: 'Done',
+            position: 1,
+            boardId: 'board-1',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            cards: [],
+          },
+        ],
+      };
+      prisma.board.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(boardWithWorkspace)
+        .mockResolvedValueOnce(boardWithLists);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.board('board-1', 'user-1');
+
+      expect(prisma.board.findUnique).toHaveBeenCalledTimes(2);
+      expect(prisma.board.findUnique).toHaveBeenNthCalledWith(1, {
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(prisma.board.findUnique).toHaveBeenNthCalledWith(2, {
+        where: { id: 'board-1' },
+        include: {
+          owner: true,
+          workspace: true,
+          lists: {
+            include: {
+              cards: {
+                orderBy: {
+                  position: 'asc',
+                },
+              },
+            },
+            orderBy: {
+              position: 'asc',
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(result).toBe(boardWithLists);
+    });
+
+    it('throws NotFoundException when boardId is empty', async () => {
+      await expect(service.board('', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when boardId is whitespace only', async () => {
+      await expect(service.board('   ', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when board does not exist', async () => {
+      prisma.board.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.board('board-1', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.board('board-1', 'user-2')).rejects.toThrow(ForbiddenException);
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+    });
+
+    it('returns board with empty lists array when board has no lists', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const boardWithEmptyLists = {
+        ...boardWithWorkspace,
+        owner: { id: 'user-1', username: 'user1', email: 'user1@example.com' },
+        workspace: boardWithWorkspace.workspace,
+        lists: [],
+      };
+      prisma.board.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(boardWithWorkspace)
+        .mockResolvedValueOnce(boardWithEmptyLists);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.board('board-1', 'user-1');
+
+      expect(result).toBe(boardWithEmptyLists);
+      expect(result?.lists).toEqual([]);
     });
   });
 });

--- a/backend/src/boards/boards.service.ts
+++ b/backend/src/boards/boards.service.ts
@@ -73,5 +73,48 @@ export class BoardsService {
       },
     });
   }
+
+  async board(boardId: string, userId: string) {
+    // Validate boardId is provided
+    if (!boardId || boardId.trim() === '') {
+      throw new NotFoundException('Board ID is required');
+    }
+
+    // Find the board with its workspace
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: {
+        workspace: true,
+      },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(board.workspaceId, userId);
+
+    // Return board with lists and cards
+    return this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: {
+        owner: true,
+        workspace: true,
+        lists: {
+          include: {
+            cards: {
+              orderBy: {
+                position: 'asc',
+              },
+            },
+          },
+          orderBy: {
+            position: 'asc',
+          },
+        },
+      },
+    });
+  }
 }
 

--- a/backend/src/boards/models/board.model.ts
+++ b/backend/src/boards/models/board.model.ts
@@ -1,4 +1,7 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { UserModel } from '../../users/models/user.model';
+import { WorkspaceModel } from '../../workspaces/models/workspace.model';
+import { ListModel } from './list.model';
 
 @ObjectType()
 export class BoardModel {
@@ -17,8 +20,17 @@ export class BoardModel {
   @Field()
   ownerId!: string;
 
+  @Field(() => UserModel, { nullable: true })
+  owner?: UserModel;
+
   @Field(() => ID)
   workspaceId!: string;
+
+  @Field(() => WorkspaceModel, { nullable: true })
+  workspace?: WorkspaceModel;
+
+  @Field(() => [ListModel], { nullable: true })
+  lists?: ListModel[];
 
   @Field()
   createdAt!: Date;

--- a/backend/src/boards/models/card.model.ts
+++ b/backend/src/boards/models/card.model.ts
@@ -1,0 +1,26 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class CardModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  title!: string;
+
+  @Field(() => String, { nullable: true })
+  description?: string | null;
+
+  @Field(() => Int)
+  position!: number;
+
+  @Field(() => ID)
+  listId!: string;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+

--- a/backend/src/boards/models/list.model.ts
+++ b/backend/src/boards/models/list.model.ts
@@ -1,0 +1,27 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
+import { CardModel } from './card.model';
+
+@ObjectType()
+export class ListModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  title!: string;
+
+  @Field(() => Int)
+  position!: number;
+
+  @Field(() => ID)
+  boardId!: string;
+
+  @Field(() => [CardModel], { nullable: true })
+  cards?: CardModel[];
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+


### PR DESCRIPTION
This pull request introduces support for lists and cards within boards, enabling hierarchical organization similar to Trello. It includes database schema updates, expanded Prisma models, GraphQL type definitions, and service and resolver logic to fetch boards with their lists and cards. Comprehensive tests are added to ensure correct behavior and access control.

**Database and Model Updates:**

* Added new `List` and `Card` tables to the database schema, including relationships and indexes for efficient querying. (`backend/prisma/migrations/20260202222658_add_list_and_card_models/migration.sql`)
* Updated Prisma schema to define `List` and `Card` models, and established relations between `Board`, `List`, and `Card`. (`backend/prisma/schema.prisma`)

**GraphQL Type Definitions:**

* Created `ListModel` and `CardModel` GraphQL object types, and updated `BoardModel` to include fields for owner, workspace, and lists. (`backend/src/boards/models/list.model.ts`, `backend/src/boards/models/card.model.ts`, `backend/src/boards/models/board.model.ts`) [[1]](diffhunk://#diff-812313d2123081a2f9fa7de36dd4b6b3a98b264a38a1a76c7a0ad59294cde476R1-R27) [[2]](diffhunk://#diff-859e7436b3c7de1d9392ec570ebdafe0f3865e46b076769e34945db805525d12R1-R26) [[3]](diffhunk://#diff-62f083378f7034b352d8b3458025ffda101f73691b1b9599095297bace730467R23-R34)

**Service and Resolver Enhancements:**

* Implemented the `board` query in both the resolver and service to fetch a board by ID, including its lists and cards, with access control. (`backend/src/boards/boards.resolver.ts`, `backend/src/boards/boards.service.ts`) [[1]](diffhunk://#diff-f6b5b942743a2af108065b80b815b06d766c8129969b303288698531582add8cR29-R34) [[2]](diffhunk://#diff-9da11eca69208809714b73595d3fc3b7b5b1e550685c106800670378e9b7b2f1R76-R118)

**Testing Improvements:**

* Added and expanded unit tests to cover fetching boards with lists and cards, including access control and error cases. (`backend/src/boards/boards.resolver.spec.ts`, `backend/src/boards/boards.service.spec.ts`) [[1]](diffhunk://#diff-5cb0629971da11634b2f0d78f8b1ef61e4b24f163152d3b7e8b33039fffa6c38R57-R88) [[2]](diffhunk://#diff-ac731734159f22e88e55c577b204a4b42ef4758ab9a0c0b49e5fa798ab5baf07R325-R508)