### PR TITLE
Add updateBoard mutation with title, description and background

### DIFF
--- a/backend/src/boards/boards.resolver.spec.ts
+++ b/backend/src/boards/boards.resolver.spec.ts
@@ -7,6 +7,7 @@ describe('BoardsResolver', () => {
     createBoard: jest.fn(),
     workspaceBoards: jest.fn(),
     board: jest.fn(),
+    updateBoard: jest.fn(),
   } as unknown as BoardsService;
   const resolver = new BoardsResolver(boardsService);
 
@@ -85,6 +86,36 @@ describe('BoardsResolver', () => {
 
     expect(boardsService.board).toHaveBeenCalledWith('board-1', 'user-1');
     expect(result).toBe(board);
+  });
+
+  it('updates a board for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = {
+      id: 'board-1',
+      title: 'Updated Board Title',
+      description: 'Updated description',
+      background: '#ff0000',
+    };
+    const updatedBoard = {
+      id: 'board-1',
+      title: 'Updated Board Title',
+      description: 'Updated description',
+      background: '#ff0000',
+      ownerId: 'user-1',
+      workspaceId: 'workspace-1',
+    };
+    boardsService.updateBoard = jest.fn().mockResolvedValue(updatedBoard);
+
+    const result = await resolver.updateBoard(input, user);
+
+    expect(boardsService.updateBoard).toHaveBeenCalledWith(
+      'board-1',
+      'Updated Board Title',
+      'user-1',
+      'Updated description',
+      '#ff0000'
+    );
+    expect(result).toBe(updatedBoard);
   });
 });
 

--- a/backend/src/boards/boards.resolver.ts
+++ b/backend/src/boards/boards.resolver.ts
@@ -2,6 +2,7 @@ import { Args, Context, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { User } from '@prisma/client';
 import { AuthGuard } from '../common/guards/gql-auth.decorator';
 import { CreateBoardInput } from './dto/create-board.input';
+import { UpdateBoardInput } from './dto/update-board.input';
 import { BoardModel } from './models/board.model';
 import { BoardsService } from './boards.service';
 
@@ -31,6 +32,21 @@ export class BoardsResolver {
   @AuthGuard()
   async board(@Args('id') id: string, @Context('user') user: User) {
     return this.boardsService.board(id, user.id);
+  }
+
+  @Mutation(() => BoardModel)
+  @AuthGuard()
+  async updateBoard(
+    @Args('input', { type: () => UpdateBoardInput }) input: UpdateBoardInput,
+    @Context('user') user: User
+  ) {
+    return this.boardsService.updateBoard(
+      input.id,
+      input.title,
+      user.id,
+      input.description,
+      input.background
+    );
   }
 }
 

--- a/backend/src/boards/boards.service.spec.ts
+++ b/backend/src/boards/boards.service.spec.ts
@@ -4,7 +4,7 @@ import { WorkspacesService } from '../workspaces/workspaces.service';
 import { BoardsService } from './boards.service';
 
 describe('BoardsService', () => {
-  const prisma = {
+    const prisma = {
     workspace: {
       findUnique: jest.fn(),
     },
@@ -15,6 +15,7 @@ describe('BoardsService', () => {
       create: jest.fn(),
       findMany: jest.fn(),
       findUnique: jest.fn(),
+      update: jest.fn(),
     },
   } as unknown as PrismaService;
   const workspacesService = {
@@ -504,6 +505,229 @@ describe('BoardsService', () => {
 
       expect(result).toBe(boardWithEmptyLists);
       expect(result?.lists).toEqual([]);
+    });
+  });
+
+  describe('updateBoard', () => {
+    it('updates board title when user is a workspace member', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'Old Title',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const updatedBoard = {
+        ...boardWithWorkspace,
+        title: 'New Title',
+        owner: { id: 'user-1', username: 'user1', email: 'user1@example.com' },
+        workspace: boardWithWorkspace.workspace,
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.board.update = jest.fn().mockResolvedValue(updatedBoard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateBoard('board-1', 'New Title', 'user-1');
+
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.board.update).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        data: { title: 'New Title' },
+        include: {
+          owner: true,
+          workspace: true,
+        },
+      });
+      expect(result).toBe(updatedBoard);
+      expect(result.title).toBe('New Title');
+    });
+
+    it('updates board with description and background when provided', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'Old Title',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const updatedBoard = {
+        ...boardWithWorkspace,
+        title: 'New Title',
+        description: 'New Description',
+        background: '#ff0000',
+        owner: { id: 'user-1', username: 'user1', email: 'user1@example.com' },
+        workspace: boardWithWorkspace.workspace,
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.board.update = jest.fn().mockResolvedValue(updatedBoard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateBoard(
+        'board-1',
+        'New Title',
+        'user-1',
+        'New Description',
+        '#ff0000'
+      );
+
+      expect(prisma.board.update).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        data: {
+          title: 'New Title',
+          description: 'New Description',
+          background: '#ff0000',
+        },
+        include: {
+          owner: true,
+          workspace: true,
+        },
+      });
+      expect(result).toBe(updatedBoard);
+      expect(result.title).toBe('New Title');
+      expect(result.description).toBe('New Description');
+      expect(result.background).toBe('#ff0000');
+    });
+
+    it('updates board with only description when background is not provided', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'Old Title',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const updatedBoard = {
+        ...boardWithWorkspace,
+        title: 'New Title',
+        description: 'New Description',
+        owner: { id: 'user-1', username: 'user1', email: 'user1@example.com' },
+        workspace: boardWithWorkspace.workspace,
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.board.update = jest.fn().mockResolvedValue(updatedBoard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateBoard('board-1', 'New Title', 'user-1', 'New Description');
+
+      expect(prisma.board.update).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        data: {
+          title: 'New Title',
+          description: 'New Description',
+        },
+        include: {
+          owner: true,
+          workspace: true,
+        },
+      });
+      expect(result.description).toBe('New Description');
+    });
+
+    it('throws NotFoundException when boardId is empty', async () => {
+      await expect(service.updateBoard('', 'New Title', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.board.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when boardId is whitespace only', async () => {
+      await expect(service.updateBoard('   ', 'New Title', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.board.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is empty', async () => {
+      await expect(service.updateBoard('board-1', '', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.board.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is whitespace only', async () => {
+      await expect(service.updateBoard('board-1', '   ', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.board.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when board does not exist', async () => {
+      prisma.board.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.updateBoard('board-1', 'New Title', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.board.update).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'Old Title',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.updateBoard('board-1', 'New Title', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.board.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/boards/boards.service.ts
+++ b/backend/src/boards/boards.service.ts
@@ -116,5 +116,61 @@ export class BoardsService {
       },
     });
   }
+
+  async updateBoard(
+    boardId: string,
+    title: string,
+    userId: string,
+    description?: string | null,
+    background?: string
+  ) {
+    // Validate boardId is provided
+    if (!boardId || boardId.trim() === '') {
+      throw new NotFoundException('Board ID is required');
+    }
+
+    // Validate title is provided
+    if (!title || title.trim() === '') {
+      throw new NotFoundException('Title is required');
+    }
+
+    // Find the board with its workspace
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: {
+        workspace: true,
+      },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(board.workspaceId, userId);
+
+    // Prepare update data
+    const updateData: { title: string; description?: string | null; background?: string } = {
+      title,
+    };
+
+    if (description !== undefined) {
+      updateData.description = description;
+    }
+
+    if (background !== undefined) {
+      updateData.background = background;
+    }
+
+    // Update the board
+    return this.prisma.board.update({
+      where: { id: boardId },
+      data: updateData,
+      include: {
+        owner: true,
+        workspace: true,
+      },
+    });
+  }
 }
 

--- a/backend/src/boards/dto/update-board.input.ts
+++ b/backend/src/boards/dto/update-board.input.ts
@@ -1,0 +1,26 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class UpdateBoardInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @Field()
+  @IsString()
+  @MinLength(1)
+  title!: string;
+
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  background?: string;
+}
+


### PR DESCRIPTION
This pull request adds support for updating boards in the backend. It introduces a new `updateBoard` mutation to the GraphQL API, implements the corresponding service logic with validation and permission checks, and provides comprehensive tests for various update scenarios and error cases.

**API and Resolver Changes:**

* Added a new `UpdateBoardInput` input type for board updates, supporting updates to `title`, `description`, and `background` (`backend/src/boards/dto/update-board.input.ts`).
* Introduced the `updateBoard` mutation in `BoardsResolver`, which uses the new input type and calls the service method to perform the update (`backend/src/boards/boards.resolver.ts`). [[1]](diffhunk://#diff-f6b5b942743a2af108065b80b815b06d766c8129969b303288698531582add8cR5) [[2]](diffhunk://#diff-f6b5b942743a2af108065b80b815b06d766c8129969b303288698531582add8cR36-R50)

**Service Layer Enhancements:**

* Implemented the `updateBoard` method in `BoardsService` with validation for required fields, checks for board existence, and workspace membership verification. The method updates only the provided fields and returns the updated board (`backend/src/boards/boards.service.ts`).

**Testing Improvements:**

* Added extensive tests for the `updateBoard` service method, covering successful updates, partial updates, and all relevant error cases (e.g., missing fields, non-existent board, insufficient permissions) (`backend/src/boards/boards.service.spec.ts`). [[1]](diffhunk://#diff-ac731734159f22e88e55c577b204a4b42ef4758ab9a0c0b49e5fa798ab5baf07R18) [[2]](diffhunk://#diff-ac731734159f22e88e55c577b204a4b42ef4758ab9a0c0b49e5fa798ab5baf07R510-R732)
* Added a unit test for the new resolver mutation to ensure correct interaction with the service (`backend/src/boards/boards.resolver.spec.ts`). [[1]](diffhunk://#diff-5cb0629971da11634b2f0d78f8b1ef61e4b24f163152d3b7e8b33039fffa6c38R10) [[2]](diffhunk://#diff-5cb0629971da11634b2f0d78f8b1ef61e4b24f163152d3b7e8b33039fffa6c38R90-R119)