### PR TITLE
Add deleteBoard mutation

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -92,6 +92,3 @@ model WorkspaceMember {
 
 
 
-
-
-

--- a/backend/src/boards/boards.resolver.spec.ts
+++ b/backend/src/boards/boards.resolver.spec.ts
@@ -8,6 +8,7 @@ describe('BoardsResolver', () => {
     workspaceBoards: jest.fn(),
     board: jest.fn(),
     updateBoard: jest.fn(),
+    deleteBoard: jest.fn(),
   } as unknown as BoardsService;
   const resolver = new BoardsResolver(boardsService);
 
@@ -116,6 +117,16 @@ describe('BoardsResolver', () => {
       '#ff0000'
     );
     expect(result).toBe(updatedBoard);
+  });
+
+  it('deletes a board for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    boardsService.deleteBoard = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.deleteBoard('board-1', user);
+
+    expect(boardsService.deleteBoard).toHaveBeenCalledWith('board-1', 'user-1');
+    expect(result).toBe(true);
   });
 });
 

--- a/backend/src/boards/boards.resolver.ts
+++ b/backend/src/boards/boards.resolver.ts
@@ -48,5 +48,11 @@ export class BoardsResolver {
       input.background
     );
   }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async deleteBoard(@Args('id') id: string, @Context('user') user: User) {
+    return this.boardsService.deleteBoard(id, user.id);
+  }
 }
 

--- a/backend/src/boards/boards.service.spec.ts
+++ b/backend/src/boards/boards.service.spec.ts
@@ -16,6 +16,7 @@ describe('BoardsService', () => {
       findMany: jest.fn(),
       findUnique: jest.fn(),
       update: jest.fn(),
+      delete: jest.fn(),
     },
   } as unknown as PrismaService;
   const workspacesService = {
@@ -728,6 +729,130 @@ describe('BoardsService', () => {
         'user-2'
       );
       expect(prisma.board.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteBoard', () => {
+    it('deletes board when user is the board creator', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-2' },
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.board.delete = jest.fn().mockResolvedValue(boardWithWorkspace);
+
+      const result = await service.deleteBoard('board-1', 'user-1');
+
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(prisma.board.delete).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('deletes board when user is the workspace owner', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-2',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.board.delete = jest.fn().mockResolvedValue(boardWithWorkspace);
+
+      const result = await service.deleteBoard('board-1', 'user-1');
+
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(prisma.board.delete).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('deletes board when user is both board creator and workspace owner', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.board.delete = jest.fn().mockResolvedValue(boardWithWorkspace);
+
+      const result = await service.deleteBoard('board-1', 'user-1');
+
+      expect(prisma.board.delete).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when boardId is empty', async () => {
+      await expect(service.deleteBoard('', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(prisma.board.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when boardId is whitespace only', async () => {
+      await expect(service.deleteBoard('   ', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(prisma.board.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when board does not exist', async () => {
+      prisma.board.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.deleteBoard('board-1', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(prisma.board.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is neither board creator nor workspace owner', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-2',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-3' },
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+
+      await expect(service.deleteBoard('board-1', 'user-1')).rejects.toThrow(ForbiddenException);
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(prisma.board.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/boards/boards.service.ts
+++ b/backend/src/boards/boards.service.ts
@@ -172,5 +172,44 @@ export class BoardsService {
       },
     });
   }
+
+  async deleteBoard(boardId: string, userId: string) {
+    // Validate boardId is provided
+    if (!boardId || boardId.trim() === '') {
+      throw new NotFoundException('Board ID is required');
+    }
+
+    // Find the board with its workspace
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: {
+        workspace: true,
+      },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Check if user is the board creator (ownerId)
+    const isBoardCreator = board.ownerId === userId;
+
+    // Check if user is the workspace owner
+    const isWorkspaceOwner = board.workspace.ownerId === userId;
+
+    // Allow deletion if user is either the board creator or workspace owner
+    if (!isBoardCreator && !isWorkspaceOwner) {
+      throw new ForbiddenException(
+        'Only the board creator or workspace owner can delete this board'
+      );
+    }
+
+    // Delete the board (lists and cards will be deleted in cascade due to onDelete: Cascade)
+    await this.prisma.board.delete({
+      where: { id: boardId },
+    });
+
+    return true;
+  }
 }
 


### PR DESCRIPTION
This pull request adds support for deleting boards, including both the resolver and service logic, and comprehensive tests to ensure only authorized users (board creator or workspace owner) can perform deletions. It also handles error scenarios such as missing or invalid board IDs and unauthorized access.

**Board Deletion Feature:**

* Added a new `deleteBoard` mutation to the `BoardsResolver`, enabling users to delete boards if they are the board creator or workspace owner.
* Implemented the `deleteBoard` method in `BoardsService`, which validates permissions, checks for board existence, and handles error cases (NotFound and Forbidden exceptions).

**Testing and Validation:**

* Added extensive unit tests for `deleteBoard` in `BoardsService`, covering successful deletion by authorized users, handling of missing/invalid board IDs, non-existent boards, and forbidden deletions by unauthorized users.
* Updated the `BoardsResolver` tests to include the new `deleteBoard` mutation and its expected behavior. [[1]](diffhunk://#diff-5cb0629971da11634b2f0d78f8b1ef61e4b24f163152d3b7e8b33039fffa6c38R11) [[2]](diffhunk://#diff-5cb0629971da11634b2f0d78f8b1ef61e4b24f163152d3b7e8b33039fffa6c38R121-R130)
* Mocked the Prisma `delete` method in service tests to support board deletion scenarios.