### PR TITLE
Add createList mutation

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthContextService } from './auth/auth.context';
 import { validateEnv } from './config/env.validation';
 import { WorkspacesModule } from './workspaces/workspaces.module';
 import { BoardsModule } from './boards/boards.module';
+import { ListsModule } from './lists/lists.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { BoardsModule } from './boards/boards.module';
     AuthModule,
     WorkspacesModule,
     BoardsModule,
+    ListsModule,
     HealthModule,
   ],
 })

--- a/backend/src/lists/dto/create-list.input.ts
+++ b/backend/src/lists/dto/create-list.input.ts
@@ -1,0 +1,16 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class CreateListInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  boardId!: string;
+
+  @Field()
+  @IsString()
+  @MinLength(1)
+  title!: string;
+}
+

--- a/backend/src/lists/lists.module.ts
+++ b/backend/src/lists/lists.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { ListsResolver } from './lists.resolver';
+import { ListsService } from './lists.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule, WorkspacesModule],
+  providers: [ListsService, ListsResolver],
+  exports: [ListsService],
+})
+export class ListsModule {}
+

--- a/backend/src/lists/lists.resolver.spec.ts
+++ b/backend/src/lists/lists.resolver.spec.ts
@@ -1,0 +1,34 @@
+import { User } from '@prisma/client';
+import { ListsResolver } from './lists.resolver';
+import { ListsService } from './lists.service';
+
+describe('ListsResolver', () => {
+  const listsService = {
+    createList: jest.fn(),
+  } as unknown as ListsService;
+  const resolver = new ListsResolver(listsService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a list for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { boardId: 'board-1', title: 'To Do' };
+    const list = {
+      id: 'list-1',
+      title: 'To Do',
+      position: 0,
+      boardId: 'board-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    listsService.createList = jest.fn().mockResolvedValue(list);
+
+    const result = await resolver.createList(input, user);
+
+    expect(listsService.createList).toHaveBeenCalledWith('board-1', 'To Do', 'user-1');
+    expect(result).toBe(list);
+  });
+});
+

--- a/backend/src/lists/lists.resolver.ts
+++ b/backend/src/lists/lists.resolver.ts
@@ -1,0 +1,21 @@
+import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
+import { User } from '@prisma/client';
+import { AuthGuard } from '../common/guards/gql-auth.decorator';
+import { CreateListInput } from './dto/create-list.input';
+import { ListModel } from '../boards/models/list.model';
+import { ListsService } from './lists.service';
+
+@Resolver(() => ListModel)
+export class ListsResolver {
+  constructor(private readonly listsService: ListsService) {}
+
+  @Mutation(() => ListModel)
+  @AuthGuard()
+  async createList(
+    @Args('input', { type: () => CreateListInput }) input: CreateListInput,
+    @Context('user') user: User
+  ) {
+    return this.listsService.createList(input.boardId, input.title, user.id);
+  }
+}
+

--- a/backend/src/lists/lists.service.spec.ts
+++ b/backend/src/lists/lists.service.spec.ts
@@ -1,0 +1,216 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+import { ListsService } from './lists.service';
+
+describe('ListsService', () => {
+  const prisma = {
+    board: {
+      findUnique: jest.fn(),
+    },
+    list: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+  } as unknown as PrismaService;
+  const workspacesService = {
+    requireWorkspaceAccess: jest.fn(),
+  } as unknown as WorkspacesService;
+  const service = new ListsService(prisma, workspacesService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createList', () => {
+    it('creates a list with position 0 when board has no lists', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const newList = {
+        id: 'list-1',
+        title: 'To Do',
+        position: 0,
+        boardId: 'board-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        board: boardWithWorkspace,
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.list.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.list.create = jest.fn().mockResolvedValue(newList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.createList('board-1', 'To Do', 'user-1');
+
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.list.findFirst).toHaveBeenCalledWith({
+        where: { boardId: 'board-1' },
+        orderBy: { position: 'desc' },
+      });
+      expect(prisma.list.create).toHaveBeenCalledWith({
+        data: {
+          title: 'To Do',
+          boardId: 'board-1',
+          position: 0,
+        },
+        include: {
+          board: true,
+        },
+      });
+      expect(result).toBe(newList);
+      expect(result.position).toBe(0);
+    });
+
+    it('creates a list with position auto-calculated when board has existing lists', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const lastList = {
+        id: 'list-1',
+        title: 'Existing List',
+        position: 2,
+        boardId: 'board-1',
+      };
+      const newList = {
+        id: 'list-2',
+        title: 'New List',
+        position: 3,
+        boardId: 'board-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        board: boardWithWorkspace,
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      prisma.list.findFirst = jest.fn().mockResolvedValue(lastList);
+      prisma.list.create = jest.fn().mockResolvedValue(newList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.createList('board-1', 'New List', 'user-1');
+
+      expect(prisma.list.findFirst).toHaveBeenCalledWith({
+        where: { boardId: 'board-1' },
+        orderBy: { position: 'desc' },
+      });
+      expect(prisma.list.create).toHaveBeenCalledWith({
+        data: {
+          title: 'New List',
+          boardId: 'board-1',
+          position: 3,
+        },
+        include: {
+          board: true,
+        },
+      });
+      expect(result).toBe(newList);
+      expect(result.position).toBe(3);
+    });
+
+    it('throws NotFoundException when boardId is empty', async () => {
+      await expect(service.createList('', 'To Do', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when boardId is whitespace only', async () => {
+      await expect(service.createList('   ', 'To Do', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is empty', async () => {
+      await expect(service.createList('board-1', '', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is whitespace only', async () => {
+      await expect(service.createList('board-1', '   ', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when board does not exist', async () => {
+      prisma.board.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.createList('board-1', 'To Do', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const boardWithWorkspace = {
+        id: 'board-1',
+        title: 'My Board',
+        description: null,
+        background: '#0079bf',
+        ownerId: 'user-1',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.board.findUnique = jest.fn().mockResolvedValue(boardWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.createList('board-1', 'To Do', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.board.findUnique).toHaveBeenCalledWith({
+        where: { id: 'board-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.list.create).not.toHaveBeenCalled();
+    });
+  });
+});
+

--- a/backend/src/lists/lists.service.ts
+++ b/backend/src/lists/lists.service.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+
+@Injectable()
+export class ListsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly workspacesService: WorkspacesService
+  ) {}
+
+  async createList(boardId: string, title: string, userId: string) {
+    // Validate boardId is provided
+    if (!boardId || boardId.trim() === '') {
+      throw new NotFoundException('Board ID is required');
+    }
+
+    // Validate title is provided
+    if (!title || title.trim() === '') {
+      throw new NotFoundException('Title is required');
+    }
+
+    // Find the board with its workspace
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: {
+        workspace: true,
+      },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(board.workspaceId, userId);
+
+    // Get the last position (highest position value) for lists in this board
+    const lastList = await this.prisma.list.findFirst({
+      where: { boardId },
+      orderBy: { position: 'desc' },
+    });
+
+    // Calculate the new position (last position + 1, or 0 if no lists exist)
+    const newPosition = lastList ? lastList.position + 1 : 0;
+
+    // Create the list with auto-calculated position
+    return this.prisma.list.create({
+      data: {
+        title,
+        boardId,
+        position: newPosition,
+      },
+      include: {
+        board: true,
+      },
+    });
+  }
+}
+


### PR DESCRIPTION
This pull request introduces a new "Lists" feature to the backend, enabling the creation and management of lists within boards. The main changes include the addition of the `ListsModule`, a GraphQL mutation for creating lists, robust input validation and authorization, and comprehensive unit tests to ensure correct behavior and access control.

**Feature: Lists (Create List API)**
- Added `ListsModule` with service, resolver, and DTO for creating lists, and integrated it into the main application module. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R13) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R34) [[3]](diffhunk://#diff-212c4ce0cd65fe13b51cb8cefcd2d64d6e4b99d62a5b02534ee5cf534e55da1bR1-R14) [[4]](diffhunk://#diff-3e3b4284fd1726180c94087f008778e469ff1ecbd9c49fa0b92e8f2b6d5bb926R1-R16)
- Implemented `ListsService` with input validation, workspace membership checks, and auto-calculation of list position within a board.
- Added `ListsResolver` with a secured GraphQL mutation for creating lists, requiring authentication and user context.

**Testing and Validation**
- Added unit tests for `ListsService`, covering list creation, input validation, board existence, and workspace access control.
- Added unit tests for `ListsResolver` to verify correct invocation of the service and response structure.