### PR TITLE
Add updateList mutation

### DIFF
--- a/backend/src/lists/dto/update-list.input.ts
+++ b/backend/src/lists/dto/update-list.input.ts
@@ -1,0 +1,16 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class UpdateListInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @Field()
+  @IsString()
+  @MinLength(1)
+  title!: string;
+}
+

--- a/backend/src/lists/lists.resolver.spec.ts
+++ b/backend/src/lists/lists.resolver.spec.ts
@@ -5,6 +5,7 @@ import { ListsService } from './lists.service';
 describe('ListsResolver', () => {
   const listsService = {
     createList: jest.fn(),
+    updateList: jest.fn(),
   } as unknown as ListsService;
   const resolver = new ListsResolver(listsService);
 
@@ -29,6 +30,25 @@ describe('ListsResolver', () => {
 
     expect(listsService.createList).toHaveBeenCalledWith('board-1', 'To Do', 'user-1');
     expect(result).toBe(list);
+  });
+
+  it('updates a list for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'list-1', title: 'Updated Title' };
+    const updatedList = {
+      id: 'list-1',
+      title: 'Updated Title',
+      position: 0,
+      boardId: 'board-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    listsService.updateList = jest.fn().mockResolvedValue(updatedList);
+
+    const result = await resolver.updateList(input, user);
+
+    expect(listsService.updateList).toHaveBeenCalledWith('list-1', 'Updated Title', 'user-1');
+    expect(result).toBe(updatedList);
   });
 });
 

--- a/backend/src/lists/lists.resolver.ts
+++ b/backend/src/lists/lists.resolver.ts
@@ -2,6 +2,7 @@ import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
 import { User } from '@prisma/client';
 import { AuthGuard } from '../common/guards/gql-auth.decorator';
 import { CreateListInput } from './dto/create-list.input';
+import { UpdateListInput } from './dto/update-list.input';
 import { ListModel } from '../boards/models/list.model';
 import { ListsService } from './lists.service';
 
@@ -16,6 +17,15 @@ export class ListsResolver {
     @Context('user') user: User
   ) {
     return this.listsService.createList(input.boardId, input.title, user.id);
+  }
+
+  @Mutation(() => ListModel)
+  @AuthGuard()
+  async updateList(
+    @Args('input', { type: () => UpdateListInput }) input: UpdateListInput,
+    @Context('user') user: User
+  ) {
+    return this.listsService.updateList(input.id, input.title, user.id);
   }
 }
 

--- a/backend/src/lists/lists.service.spec.ts
+++ b/backend/src/lists/lists.service.spec.ts
@@ -11,6 +11,8 @@ describe('ListsService', () => {
     list: {
       findFirst: jest.fn(),
       create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
     },
   } as unknown as PrismaService;
   const workspacesService = {
@@ -210,6 +212,158 @@ describe('ListsService', () => {
         'user-2'
       );
       expect(prisma.list.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateList', () => {
+    it('updates a list when user is a workspace member', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'Old Title',
+        position: 0,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      const updatedList = {
+        id: 'list-1',
+        title: 'New Title',
+        position: 0,
+        boardId: 'board-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        board: listWithBoard.board,
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      prisma.list.update = jest.fn().mockResolvedValue(updatedList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateList('list-1', 'New Title', 'user-1');
+
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.list.update).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        data: {
+          title: 'New Title',
+        },
+        include: {
+          board: true,
+        },
+      });
+      expect(result).toBe(updatedList);
+      expect(result.title).toBe('New Title');
+    });
+
+    it('throws NotFoundException when listId is empty', async () => {
+      await expect(service.updateList('', 'New Title', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when listId is whitespace only', async () => {
+      await expect(service.updateList('   ', 'New Title', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is empty', async () => {
+      await expect(service.updateList('list-1', '', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is whitespace only', async () => {
+      await expect(service.updateList('list-1', '   ', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when list does not exist', async () => {
+      prisma.list.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.updateList('list-1', 'New Title', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'Old Title',
+        position: 0,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.updateList('list-1', 'New Title', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.list.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/lists/lists.service.ts
+++ b/backend/src/lists/lists.service.ts
@@ -56,5 +56,47 @@ export class ListsService {
       },
     });
   }
+
+  async updateList(listId: string, title: string, userId: string) {
+    // Validate listId is provided
+    if (!listId || listId.trim() === '') {
+      throw new NotFoundException('List ID is required');
+    }
+
+    // Validate title is provided
+    if (!title || title.trim() === '') {
+      throw new NotFoundException('Title is required');
+    }
+
+    // Find the list with its board and workspace
+    const list = await this.prisma.list.findUnique({
+      where: { id: listId },
+      include: {
+        board: {
+          include: {
+            workspace: true,
+          },
+        },
+      },
+    });
+
+    if (!list) {
+      throw new NotFoundException('List not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(list.board.workspaceId, userId);
+
+    // Update the list
+    return this.prisma.list.update({
+      where: { id: listId },
+      data: {
+        title,
+      },
+      include: {
+        board: true,
+      },
+    });
+  }
 }
 


### PR DESCRIPTION
This pull request adds support for updating a list's title, including API, service, DTO, and comprehensive test coverage. The changes ensure that only authorized users can update lists and that appropriate validation and error handling are in place.

**API and DTO Enhancements:**
- Added a new `UpdateListInput` DTO with validation for `id` and `title`.
- Updated the GraphQL resolver to include an `updateList` mutation, which uses the new DTO and is protected by authentication. [[1]](diffhunk://#diff-23d3eaa99c40f6bf562a32e4482f023741b56d46381145dae5de4d6da1d94b40R5) [[2]](diffhunk://#diff-23d3eaa99c40f6bf562a32e4482f023741b56d46381145dae5de4d6da1d94b40R21-R29)

**Service Layer Updates:**
- Implemented the `updateList` method in `ListsService`, including validation, permission checks, and updating the list in the database.

**Testing Improvements:**
- Added extensive unit tests for the `updateList` service, covering successful updates, validation errors, not found cases, and permission checks. [[1]](diffhunk://#diff-ccb33305d9a842469898752736539c3eeb704ce243ddbc51acc205ffb4c8751dR217-R368) [[2]](diffhunk://#diff-ccb33305d9a842469898752736539c3eeb704ce243ddbc51acc205ffb4c8751dR14-R15)
- Added a resolver test for the `updateList` mutation to verify integration with the service and correct argument passing. [[1]](diffhunk://#diff-c7319170f82011dbb1fd2b48ec331481347bf1af20905c3ad70310c58057c1a1R8) [[2]](diffhunk://#diff-c7319170f82011dbb1fd2b48ec331481347bf1af20905c3ad70310c58057c1a1R34-R52)