### PR TITLE
Add archiveList mutation

### DIFF
--- a/backend/prisma/migrations/20260203154205_add_archived_to_list/migration.sql
+++ b/backend/prisma/migrations/20260203154205_add_archived_to_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "List" ADD COLUMN     "archived" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -39,6 +39,7 @@ model List {
   id          String   @id @default(uuid())
   title       String
   position    Int      @default(0)
+  archived    Boolean  @default(false)
   boardId     String
   board       Board    @relation(fields: [boardId], references: [id], onDelete: Cascade)
   cards       Card[]

--- a/backend/src/boards/models/list.model.ts
+++ b/backend/src/boards/models/list.model.ts
@@ -12,6 +12,9 @@ export class ListModel {
   @Field(() => Int)
   position!: number;
 
+  @Field(() => Boolean)
+  archived!: boolean;
+
   @Field(() => ID)
   boardId!: string;
 

--- a/backend/src/lists/dto/archive-list.input.ts
+++ b/backend/src/lists/dto/archive-list.input.ts
@@ -1,0 +1,15 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+
+@InputType()
+export class ArchiveListInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @Field(() => Boolean)
+  @IsBoolean()
+  archived!: boolean;
+}
+

--- a/backend/src/lists/lists.resolver.spec.ts
+++ b/backend/src/lists/lists.resolver.spec.ts
@@ -6,6 +6,7 @@ describe('ListsResolver', () => {
   const listsService = {
     createList: jest.fn(),
     updateList: jest.fn(),
+    archiveList: jest.fn(),
   } as unknown as ListsService;
   const resolver = new ListsResolver(listsService);
 
@@ -49,6 +50,46 @@ describe('ListsResolver', () => {
 
     expect(listsService.updateList).toHaveBeenCalledWith('list-1', 'Updated Title', 'user-1');
     expect(result).toBe(updatedList);
+  });
+
+  it('archives a list for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'list-1', archived: true };
+    const archivedList = {
+      id: 'list-1',
+      title: 'My List',
+      position: 0,
+      archived: true,
+      boardId: 'board-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    listsService.archiveList = jest.fn().mockResolvedValue(archivedList);
+
+    const result = await resolver.archiveList(input, user);
+
+    expect(listsService.archiveList).toHaveBeenCalledWith('list-1', true, 'user-1');
+    expect(result).toBe(archivedList);
+  });
+
+  it('unarchives a list for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'list-1', archived: false };
+    const unarchivedList = {
+      id: 'list-1',
+      title: 'My List',
+      position: 0,
+      archived: false,
+      boardId: 'board-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    listsService.archiveList = jest.fn().mockResolvedValue(unarchivedList);
+
+    const result = await resolver.archiveList(input, user);
+
+    expect(listsService.archiveList).toHaveBeenCalledWith('list-1', false, 'user-1');
+    expect(result).toBe(unarchivedList);
   });
 });
 

--- a/backend/src/lists/lists.resolver.ts
+++ b/backend/src/lists/lists.resolver.ts
@@ -3,6 +3,7 @@ import { User } from '@prisma/client';
 import { AuthGuard } from '../common/guards/gql-auth.decorator';
 import { CreateListInput } from './dto/create-list.input';
 import { UpdateListInput } from './dto/update-list.input';
+import { ArchiveListInput } from './dto/archive-list.input';
 import { ListModel } from '../boards/models/list.model';
 import { ListsService } from './lists.service';
 
@@ -26,6 +27,15 @@ export class ListsResolver {
     @Context('user') user: User
   ) {
     return this.listsService.updateList(input.id, input.title, user.id);
+  }
+
+  @Mutation(() => ListModel)
+  @AuthGuard()
+  async archiveList(
+    @Args('input', { type: () => ArchiveListInput }) input: ArchiveListInput,
+    @Context('user') user: User
+  ) {
+    return this.listsService.archiveList(input.id, input.archived, user.id);
   }
 }
 

--- a/backend/src/lists/lists.service.spec.ts
+++ b/backend/src/lists/lists.service.spec.ts
@@ -366,5 +366,186 @@ describe('ListsService', () => {
       expect(prisma.list.update).not.toHaveBeenCalled();
     });
   });
+
+  describe('archiveList', () => {
+    it('archives a list when user is a workspace member and archived is true', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      const archivedList = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: true,
+        boardId: 'board-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        board: listWithBoard.board,
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      prisma.list.update = jest.fn().mockResolvedValue(archivedList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.archiveList('list-1', true, 'user-1');
+
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.list.update).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        data: {
+          archived: true,
+        },
+        include: {
+          board: true,
+        },
+      });
+      expect(result).toBe(archivedList);
+      expect(result.archived).toBe(true);
+    });
+
+    it('unarchives a list when user is a workspace member and archived is false', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: true,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      const unarchivedList = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: false,
+        boardId: 'board-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        board: listWithBoard.board,
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      prisma.list.update = jest.fn().mockResolvedValue(unarchivedList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.archiveList('list-1', false, 'user-1');
+
+      expect(prisma.list.update).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        data: {
+          archived: false,
+        },
+        include: {
+          board: true,
+        },
+      });
+      expect(result).toBe(unarchivedList);
+      expect(result.archived).toBe(false);
+    });
+
+    it('throws NotFoundException when listId is empty', async () => {
+      await expect(service.archiveList('', true, 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when listId is whitespace only', async () => {
+      await expect(service.archiveList('   ', true, 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when list does not exist', async () => {
+      prisma.list.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.archiveList('list-1', true, 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.archiveList('list-1', true, 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+  });
 });
 

--- a/backend/src/lists/lists.service.ts
+++ b/backend/src/lists/lists.service.ts
@@ -98,5 +98,42 @@ export class ListsService {
       },
     });
   }
+
+  async archiveList(listId: string, archived: boolean, userId: string) {
+    // Validate listId is provided
+    if (!listId || listId.trim() === '') {
+      throw new NotFoundException('List ID is required');
+    }
+
+    // Find the list with its board and workspace
+    const list = await this.prisma.list.findUnique({
+      where: { id: listId },
+      include: {
+        board: {
+          include: {
+            workspace: true,
+          },
+        },
+      },
+    });
+
+    if (!list) {
+      throw new NotFoundException('List not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(list.board.workspaceId, userId);
+
+    // Update the list archived status
+    return this.prisma.list.update({
+      where: { id: listId },
+      data: {
+        archived,
+      },
+      include: {
+        board: true,
+      },
+    });
+  }
 }
 


### PR DESCRIPTION
This pull request adds support for archiving and unarchiving lists in the backend. It introduces a new `archived` boolean field to the `List` model, exposes this functionality via a GraphQL mutation, and includes comprehensive tests for the new feature.

**Database and Model Changes:**

- Added an `archived` boolean column to the `List` table in the database, defaulting to `false`. (`backend/prisma/migrations/20260203154205_add_archived_to_list/migration.sql`, `backend/prisma/schema.prisma`) [[1]](diffhunk://#diff-2a4c312e8a129873fc51031ce6cf1994bf8ffe9f55a0c0393e39c72361a15e5bR1-R2) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR42)
- Updated the `ListModel` GraphQL model to include the new `archived` field. (`backend/src/boards/models/list.model.ts`)

**API and Business Logic:**

- Introduced a new `ArchiveListInput` input type and a corresponding `archiveList` mutation in the `ListsResolver`, allowing clients to archive or unarchive a list. (`backend/src/lists/dto/archive-list.input.ts`, `backend/src/lists/lists.resolver.ts`) [[1]](diffhunk://#diff-ebc1c5df41757402e51ea53c1873a5548b25893db61899f344408df6702d9a36R1-R15) [[2]](diffhunk://#diff-23d3eaa99c40f6bf562a32e4482f023741b56d46381145dae5de4d6da1d94b40R6) [[3]](diffhunk://#diff-23d3eaa99c40f6bf562a32e4482f023741b56d46381145dae5de4d6da1d94b40R31-R39)
- Implemented the `archiveList` method in the `ListsService`, including validation, access control, and updating the archived status. (`backend/src/lists/lists.service.ts`)

**Testing:**

- Added unit tests for archiving and unarchiving lists, as well as error cases (e.g., list not found, forbidden access) in both the service and resolver layers. (`backend/src/lists/lists.resolver.spec.ts`, `backend/src/lists/lists.service.spec.ts`) [[1]](diffhunk://#diff-c7319170f82011dbb1fd2b48ec331481347bf1af20905c3ad70310c58057c1a1R9) [[2]](diffhunk://#diff-c7319170f82011dbb1fd2b48ec331481347bf1af20905c3ad70310c58057c1a1R54-R93) [[3]](diffhunk://#diff-ccb33305d9a842469898752736539c3eeb704ce243ddbc51acc205ffb4c8751dR369-R549)