### PR TITLE
Add deleteList mutation with automatic position reorganization

### DIFF
--- a/backend/src/lists/lists.resolver.spec.ts
+++ b/backend/src/lists/lists.resolver.spec.ts
@@ -7,6 +7,7 @@ describe('ListsResolver', () => {
     createList: jest.fn(),
     updateList: jest.fn(),
     archiveList: jest.fn(),
+    deleteList: jest.fn(),
   } as unknown as ListsService;
   const resolver = new ListsResolver(listsService);
 
@@ -90,6 +91,16 @@ describe('ListsResolver', () => {
 
     expect(listsService.archiveList).toHaveBeenCalledWith('list-1', false, 'user-1');
     expect(result).toBe(unarchivedList);
+  });
+
+  it('deletes a list for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    listsService.deleteList = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.deleteList('list-1', user);
+
+    expect(listsService.deleteList).toHaveBeenCalledWith('list-1', 'user-1');
+    expect(result).toBe(true);
   });
 });
 

--- a/backend/src/lists/lists.resolver.ts
+++ b/backend/src/lists/lists.resolver.ts
@@ -37,5 +37,11 @@ export class ListsResolver {
   ) {
     return this.listsService.archiveList(input.id, input.archived, user.id);
   }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async deleteList(@Args('id') id: string, @Context('user') user: User) {
+    return this.listsService.deleteList(id, user.id);
+  }
 }
 

--- a/backend/src/lists/lists.service.spec.ts
+++ b/backend/src/lists/lists.service.spec.ts
@@ -13,7 +13,10 @@ describe('ListsService', () => {
       create: jest.fn(),
       findUnique: jest.fn(),
       update: jest.fn(),
+      delete: jest.fn(),
+      updateMany: jest.fn(),
     },
+    $transaction: jest.fn(),
   } as unknown as PrismaService;
   const workspacesService = {
     requireWorkspaceAccess: jest.fn(),
@@ -545,6 +548,161 @@ describe('ListsService', () => {
         'user-2'
       );
       expect(prisma.list.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteList', () => {
+    it('deletes a list and reorganizes positions when user is a workspace member', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 1,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      prisma.$transaction = jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          list: {
+            delete: jest.fn().mockResolvedValue(listWithBoard),
+            updateMany: jest.fn().mockResolvedValue({ count: 2 }),
+          },
+        };
+        return callback(tx);
+      });
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.deleteList('list-1', 'user-1');
+
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('deletes a list at the end without reorganizing when user is a workspace member', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 2,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      prisma.$transaction = jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          list: {
+            delete: jest.fn().mockResolvedValue(listWithBoard),
+            updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          },
+        };
+        return callback(tx);
+      });
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.deleteList('list-1', 'user-1');
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when listId is empty', async () => {
+      await expect(service.deleteList('', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when listId is whitespace only', async () => {
+      await expect(service.deleteList('   ', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when list does not exist', async () => {
+      prisma.list.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.deleteList('list-1', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.deleteList('list-1', 'user-2')).rejects.toThrow(ForbiddenException);
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.$transaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/lists/lists.service.ts
+++ b/backend/src/lists/lists.service.ts
@@ -135,5 +135,56 @@ export class ListsService {
       },
     });
   }
+
+  async deleteList(listId: string, userId: string) {
+    // Validate listId is provided
+    if (!listId || listId.trim() === '') {
+      throw new NotFoundException('List ID is required');
+    }
+
+    // Find the list with its board and workspace
+    const list = await this.prisma.list.findUnique({
+      where: { id: listId },
+      include: {
+        board: {
+          include: {
+            workspace: true,
+          },
+        },
+      },
+    });
+
+    if (!list) {
+      throw new NotFoundException('List not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(list.board.workspaceId, userId);
+
+    // Use a transaction to delete the list and reorganize positions
+    await this.prisma.$transaction(async (tx) => {
+      // Delete the list (cards will be deleted in cascade due to onDelete: Cascade)
+      await tx.list.delete({
+        where: { id: listId },
+      });
+
+      // Reorganize positions: decrement positions of all lists after the deleted one
+      await tx.list.updateMany({
+        where: {
+          boardId: list.boardId,
+          position: {
+            gt: list.position,
+          },
+        },
+        data: {
+          position: {
+            decrement: 1,
+          },
+        },
+      });
+    });
+
+    return true;
+  }
 }
 


### PR DESCRIPTION
This pull request adds support for deleting lists, including backend logic, GraphQL resolver, and comprehensive tests. The new `deleteList` functionality ensures that only authorized users can delete lists, handles edge cases, and maintains the correct ordering of remaining lists.

**Backend Logic and API:**

* Added a `deleteList` method to `ListsService` that validates input, checks user permissions, deletes the list in a transaction, and reorganizes positions of remaining lists.
* Introduced a new `deleteList` mutation in `ListsResolver` to expose the deletion functionality via the GraphQL API, protected by authentication.

**Testing:**

* Added extensive tests for `deleteList` in `ListsService`, covering successful deletion, position reordering, and various failure scenarios (missing list, unauthorized user, invalid input).
* Added a test for the `deleteList` resolver to verify correct service invocation and result.

**Supporting Changes:**

* Mocked new methods in service and Prisma mocks to support testing of deletion and transactions. [[1]](diffhunk://#diff-c7319170f82011dbb1fd2b48ec331481347bf1af20905c3ad70310c58057c1a1R10) [[2]](diffhunk://#diff-ccb33305d9a842469898752736539c3eeb704ce243ddbc51acc205ffb4c8751dR16-R19)