### PR TITLE
Add createCard mutation

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { validateEnv } from './config/env.validation';
 import { WorkspacesModule } from './workspaces/workspaces.module';
 import { BoardsModule } from './boards/boards.module';
 import { ListsModule } from './lists/lists.module';
+import { CardsModule } from './cards/cards.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { ListsModule } from './lists/lists.module';
     WorkspacesModule,
     BoardsModule,
     ListsModule,
+    CardsModule,
     HealthModule,
   ],
 })

--- a/backend/src/cards/cards.module.ts
+++ b/backend/src/cards/cards.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { CardsResolver } from './cards.resolver';
+import { CardsService } from './cards.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule, WorkspacesModule],
+  providers: [CardsService, CardsResolver],
+  exports: [CardsService],
+})
+export class CardsModule {}
+

--- a/backend/src/cards/cards.resolver.spec.ts
+++ b/backend/src/cards/cards.resolver.spec.ts
@@ -1,0 +1,35 @@
+import { User } from '@prisma/client';
+import { CardsResolver } from './cards.resolver';
+import { CardsService } from './cards.service';
+
+describe('CardsResolver', () => {
+  const cardsService = {
+    createCard: jest.fn(),
+  } as unknown as CardsService;
+  const resolver = new CardsResolver(cardsService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a card for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { listId: 'list-1', title: 'My Card' };
+    const card = {
+      id: 'card-1',
+      title: 'My Card',
+      description: null,
+      position: 0,
+      listId: 'list-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    cardsService.createCard = jest.fn().mockResolvedValue(card);
+
+    const result = await resolver.createCard(input, user);
+
+    expect(cardsService.createCard).toHaveBeenCalledWith('list-1', 'My Card', 'user-1');
+    expect(result).toBe(card);
+  });
+});
+

--- a/backend/src/cards/cards.resolver.ts
+++ b/backend/src/cards/cards.resolver.ts
@@ -1,0 +1,21 @@
+import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
+import { User } from '@prisma/client';
+import { AuthGuard } from '../common/guards/gql-auth.decorator';
+import { CreateCardInput } from './dto/create-card.input';
+import { CardModel } from '../boards/models/card.model';
+import { CardsService } from './cards.service';
+
+@Resolver(() => CardModel)
+export class CardsResolver {
+  constructor(private readonly cardsService: CardsService) {}
+
+  @Mutation(() => CardModel)
+  @AuthGuard()
+  async createCard(
+    @Args('input', { type: () => CreateCardInput }) input: CreateCardInput,
+    @Context('user') user: User
+  ) {
+    return this.cardsService.createCard(input.listId, input.title, user.id);
+  }
+}
+

--- a/backend/src/cards/cards.service.spec.ts
+++ b/backend/src/cards/cards.service.spec.ts
@@ -1,0 +1,244 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+import { CardsService } from './cards.service';
+
+describe('CardsService', () => {
+  const prisma = {
+    list: {
+      findUnique: jest.fn(),
+    },
+    card: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+  } as unknown as PrismaService;
+  const workspacesService = {
+    requireWorkspaceAccess: jest.fn(),
+  } as unknown as WorkspacesService;
+  const service = new CardsService(prisma, workspacesService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createCard', () => {
+    it('creates a card with position 0 when list has no cards', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      const newCard = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        listId: 'list-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        list: listWithBoard,
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      prisma.card.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.card.create = jest.fn().mockResolvedValue(newCard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.createCard('list-1', 'My Card', 'user-1');
+
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.card.findFirst).toHaveBeenCalledWith({
+        where: { listId: 'list-1' },
+        orderBy: { position: 'desc' },
+      });
+      expect(prisma.card.create).toHaveBeenCalledWith({
+        data: {
+          title: 'My Card',
+          listId: 'list-1',
+          position: 0,
+        },
+        include: {
+          list: true,
+        },
+      });
+      expect(result).toBe(newCard);
+      expect(result.position).toBe(0);
+    });
+
+    it('creates a card with position auto-calculated when list has existing cards', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      const lastCard = {
+        id: 'card-1',
+        title: 'Existing Card',
+        position: 2,
+        listId: 'list-1',
+      };
+      const newCard = {
+        id: 'card-2',
+        title: 'New Card',
+        description: null,
+        position: 3,
+        listId: 'list-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        list: listWithBoard,
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      prisma.card.findFirst = jest.fn().mockResolvedValue(lastCard);
+      prisma.card.create = jest.fn().mockResolvedValue(newCard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.createCard('list-1', 'New Card', 'user-1');
+
+      expect(prisma.card.findFirst).toHaveBeenCalledWith({
+        where: { listId: 'list-1' },
+        orderBy: { position: 'desc' },
+      });
+      expect(prisma.card.create).toHaveBeenCalledWith({
+        data: {
+          title: 'New Card',
+          listId: 'list-1',
+          position: 3,
+        },
+        include: {
+          list: true,
+        },
+      });
+      expect(result).toBe(newCard);
+      expect(result.position).toBe(3);
+    });
+
+    it('throws NotFoundException when listId is empty', async () => {
+      await expect(service.createCard('', 'My Card', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when listId is whitespace only', async () => {
+      await expect(service.createCard('   ', 'My Card', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is empty', async () => {
+      await expect(service.createCard('list-1', '', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is whitespace only', async () => {
+      await expect(service.createCard('list-1', '   ', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when list does not exist', async () => {
+      prisma.list.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.createCard('list-1', 'My Card', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const listWithBoard = {
+        id: 'list-1',
+        title: 'My List',
+        position: 0,
+        archived: false,
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      };
+      prisma.list.findUnique = jest.fn().mockResolvedValue(listWithBoard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.createCard('list-1', 'My Card', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.list.findUnique).toHaveBeenCalledWith({
+        where: { id: 'list-1' },
+        include: {
+          board: {
+            include: {
+              workspace: true,
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.card.create).not.toHaveBeenCalled();
+    });
+  });
+});
+

--- a/backend/src/cards/cards.service.ts
+++ b/backend/src/cards/cards.service.ts
@@ -1,0 +1,64 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+
+@Injectable()
+export class CardsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly workspacesService: WorkspacesService
+  ) {}
+
+  async createCard(listId: string, title: string, userId: string) {
+    // Validate listId is provided
+    if (!listId || listId.trim() === '') {
+      throw new NotFoundException('List ID is required');
+    }
+
+    // Validate title is provided
+    if (!title || title.trim() === '') {
+      throw new NotFoundException('Title is required');
+    }
+
+    // Find the list with its board and workspace
+    const list = await this.prisma.list.findUnique({
+      where: { id: listId },
+      include: {
+        board: {
+          include: {
+            workspace: true,
+          },
+        },
+      },
+    });
+
+    if (!list) {
+      throw new NotFoundException('List not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(list.board.workspaceId, userId);
+
+    // Get the last position (highest position value) for cards in this list
+    const lastCard = await this.prisma.card.findFirst({
+      where: { listId },
+      orderBy: { position: 'desc' },
+    });
+
+    // Calculate the new position (last position + 1, or 0 if no cards exist)
+    const newPosition = lastCard ? lastCard.position + 1 : 0;
+
+    // Create the card with auto-calculated position
+    return this.prisma.card.create({
+      data: {
+        title,
+        listId,
+        position: newPosition,
+      },
+      include: {
+        list: true,
+      },
+    });
+  }
+}
+

--- a/backend/src/cards/dto/create-card.input.ts
+++ b/backend/src/cards/dto/create-card.input.ts
@@ -1,0 +1,16 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class CreateCardInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  listId!: string;
+
+  @Field()
+  @IsString()
+  @MinLength(1)
+  title!: string;
+}
+


### PR DESCRIPTION
This pull request introduces a new "cards" feature to the backend, allowing users to create cards within lists. It includes the new `CardsModule`, a resolver and service for card creation, input validation, and comprehensive tests covering both service and resolver logic.

**Cards Feature Implementation:**

* Added new `CardsModule` with dependencies on `PrismaModule`, `AuthModule`, and `WorkspacesModule`, and exported the `CardsService` for use in other modules. (`backend/src/cards/cards.module.ts`)
* Implemented `CardsService` with a `createCard` method that validates input, checks for list existence and user workspace access, calculates the card's position, and creates the card in the database. (`backend/src/cards/cards.service.ts`)
* Created `CardsResolver` with a GraphQL mutation `createCard` that requires authentication and delegates to the service. (`backend/src/cards/cards.resolver.ts`)
* Defined `CreateCardInput` DTO with validation for `listId` and `title` fields. (`backend/src/cards/dto/create-card.input.ts`)

**Integration and Wiring:**

* Registered `CardsModule` in the main application module imports. (`backend/src/app.module.ts`) [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R14) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R36)

**Testing:**

* Added unit tests for `CardsService` covering successful card creation, input validation, list existence, and workspace access checks. (`backend/src/cards/cards.service.spec.ts`)
* Added unit test for `CardsResolver` ensuring it calls the service as expected. (`backend/src/cards/cards.resolver.spec.ts`)