### PR TITLE
Add updateCard mutation

### DIFF
--- a/backend/src/cards/cards.resolver.spec.ts
+++ b/backend/src/cards/cards.resolver.spec.ts
@@ -5,6 +5,7 @@ import { CardsService } from './cards.service';
 describe('CardsResolver', () => {
   const cardsService = {
     createCard: jest.fn(),
+    updateCard: jest.fn(),
   } as unknown as CardsService;
   const resolver = new CardsResolver(cardsService);
 
@@ -30,6 +31,71 @@ describe('CardsResolver', () => {
 
     expect(cardsService.createCard).toHaveBeenCalledWith('list-1', 'My Card', 'user-1');
     expect(result).toBe(card);
+  });
+
+  it('updates a card for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'card-1', title: 'Updated Title', description: 'Updated description' };
+    const updatedCard = {
+      id: 'card-1',
+      title: 'Updated Title',
+      description: 'Updated description',
+      position: 0,
+      listId: 'list-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    cardsService.updateCard = jest.fn().mockResolvedValue(updatedCard);
+
+    const result = await resolver.updateCard(input, user);
+
+    expect(cardsService.updateCard).toHaveBeenCalledWith(
+      'card-1',
+      'user-1',
+      'Updated Title',
+      'Updated description'
+    );
+    expect(result).toBe(updatedCard);
+  });
+
+  it('updates a card with only title for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'card-1', title: 'Updated Title' };
+    const updatedCard = {
+      id: 'card-1',
+      title: 'Updated Title',
+      description: null,
+      position: 0,
+      listId: 'list-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    cardsService.updateCard = jest.fn().mockResolvedValue(updatedCard);
+
+    const result = await resolver.updateCard(input, user);
+
+    expect(cardsService.updateCard).toHaveBeenCalledWith('card-1', 'user-1', 'Updated Title', undefined);
+    expect(result).toBe(updatedCard);
+  });
+
+  it('updates a card with only description for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'card-1', description: 'New description' };
+    const updatedCard = {
+      id: 'card-1',
+      title: 'My Card',
+      description: 'New description',
+      position: 0,
+      listId: 'list-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    cardsService.updateCard = jest.fn().mockResolvedValue(updatedCard);
+
+    const result = await resolver.updateCard(input, user);
+
+    expect(cardsService.updateCard).toHaveBeenCalledWith('card-1', 'user-1', undefined, 'New description');
+    expect(result).toBe(updatedCard);
   });
 });
 

--- a/backend/src/cards/cards.resolver.ts
+++ b/backend/src/cards/cards.resolver.ts
@@ -2,6 +2,7 @@ import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
 import { User } from '@prisma/client';
 import { AuthGuard } from '../common/guards/gql-auth.decorator';
 import { CreateCardInput } from './dto/create-card.input';
+import { UpdateCardInput } from './dto/update-card.input';
 import { CardModel } from '../boards/models/card.model';
 import { CardsService } from './cards.service';
 
@@ -16,6 +17,15 @@ export class CardsResolver {
     @Context('user') user: User
   ) {
     return this.cardsService.createCard(input.listId, input.title, user.id);
+  }
+
+  @Mutation(() => CardModel)
+  @AuthGuard()
+  async updateCard(
+    @Args('input', { type: () => UpdateCardInput }) input: UpdateCardInput,
+    @Context('user') user: User
+  ) {
+    return this.cardsService.updateCard(input.id, user.id, input.title, input.description);
   }
 }
 

--- a/backend/src/cards/cards.service.spec.ts
+++ b/backend/src/cards/cards.service.spec.ts
@@ -11,6 +11,8 @@ describe('CardsService', () => {
     card: {
       findFirst: jest.fn(),
       create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
     },
   } as unknown as PrismaService;
   const workspacesService = {
@@ -238,6 +240,346 @@ describe('CardsService', () => {
         'user-2'
       );
       expect(prisma.card.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateCard', () => {
+    it('updates a card title when user is a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'Old Title',
+        description: null,
+        position: 0,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      const updatedCard = {
+        id: 'card-1',
+        title: 'New Title',
+        description: null,
+        position: 0,
+        listId: 'list-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        list: cardWithList.list,
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithList)
+        .mockResolvedValueOnce(updatedCard);
+      prisma.card.update = jest.fn().mockResolvedValue(updatedCard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateCard('card-1', 'user-1', 'New Title', undefined);
+
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.card.update).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        data: {
+          title: 'New Title',
+        },
+        include: {
+          list: true,
+        },
+      });
+      expect(result).toBe(updatedCard);
+      expect(result?.title).toBe('New Title');
+    });
+
+    it('updates a card description when user is a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      const updatedCard = {
+        id: 'card-1',
+        title: 'My Card',
+        description: 'New description',
+        position: 0,
+        listId: 'list-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        list: cardWithList.list,
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithList)
+        .mockResolvedValueOnce(updatedCard);
+      prisma.card.update = jest.fn().mockResolvedValue(updatedCard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateCard('card-1', 'user-1', undefined, 'New description');
+
+      expect(prisma.card.update).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        data: {
+          description: 'New description',
+        },
+        include: {
+          list: true,
+        },
+      });
+      expect(result).toBe(updatedCard);
+      expect(result?.description).toBe('New description');
+    });
+
+    it('updates both title and description when user is a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'Old Title',
+        description: 'Old description',
+        position: 0,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      const updatedCard = {
+        id: 'card-1',
+        title: 'New Title',
+        description: 'New description',
+        position: 0,
+        listId: 'list-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        list: cardWithList.list,
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithList)
+        .mockResolvedValueOnce(updatedCard);
+      prisma.card.update = jest.fn().mockResolvedValue(updatedCard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateCard('card-1', 'user-1', 'New Title', 'New description');
+
+      expect(prisma.card.update).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        data: {
+          title: 'New Title',
+          description: 'New description',
+        },
+        include: {
+          list: true,
+        },
+      });
+      expect(result).toBe(updatedCard);
+      expect(result?.title).toBe('New Title');
+      expect(result?.description).toBe('New description');
+    });
+
+    it('returns card as is when no fields are provided for update', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithList)
+        .mockResolvedValueOnce(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateCard('card-1', 'user-1', undefined, undefined);
+
+      expect(prisma.card.update).not.toHaveBeenCalled();
+      expect(prisma.card.findUnique).toHaveBeenCalledTimes(2);
+      expect(result).toBe(cardWithList);
+    });
+
+    it('throws NotFoundException when cardId is empty', async () => {
+      await expect(service.updateCard('', 'user-1', 'New Title', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when cardId is whitespace only', async () => {
+      await expect(service.updateCard('   ', 'user-1', 'New Title', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when title is empty string', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      await expect(service.updateCard('card-1', 'user-1', '', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when card does not exist', async () => {
+      prisma.card.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.updateCard('card-1', 'user-1', 'New Title', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.card.update).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.updateCard('card-1', 'user-2', 'New Title', undefined)).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.card.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/cards/cards.service.ts
+++ b/backend/src/cards/cards.service.ts
@@ -60,5 +60,80 @@ export class CardsService {
       },
     });
   }
+
+  async updateCard(
+    cardId: string,
+    userId: string,
+    title?: string | null,
+    description?: string | null
+  ) {
+    // Validate cardId is provided
+    if (!cardId || cardId.trim() === '') {
+      throw new NotFoundException('Card ID is required');
+    }
+
+    // Find the card with its list, board and workspace
+    const card = await this.prisma.card.findUnique({
+      where: { id: cardId },
+      include: {
+        list: {
+          include: {
+            board: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new NotFoundException('Card not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(
+      card.list.board.workspaceId,
+      userId
+    );
+
+    // Prepare update data
+    const updateData: { title?: string; description?: string | null } = {};
+
+    if (title !== undefined) {
+      // If title is provided, validate it's not empty
+      if (title !== null && title.trim() === '') {
+        throw new NotFoundException('Title cannot be empty');
+      }
+      // Only include title if it's not null (Prisma doesn't allow null for title)
+      if (title !== null) {
+        updateData.title = title;
+      }
+    }
+
+    if (description !== undefined) {
+      updateData.description = description;
+    }
+
+    // If no fields to update, return the card as is
+    if (Object.keys(updateData).length === 0) {
+      return this.prisma.card.findUnique({
+        where: { id: cardId },
+        include: {
+          list: true,
+        },
+      });
+    }
+
+    // Update the card
+    return this.prisma.card.update({
+      where: { id: cardId },
+      data: updateData,
+      include: {
+        list: true,
+      },
+    });
+  }
 }
 

--- a/backend/src/cards/dto/update-card.input.ts
+++ b/backend/src/cards/dto/update-card.input.ts
@@ -1,0 +1,22 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class UpdateCardInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  title?: string | null;
+
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+}
+


### PR DESCRIPTION
This pull request adds the ability to update cards in the application, including support for updating the card's title and/or description. It introduces a new GraphQL mutation, input type, and comprehensive tests for both the resolver and service layers, covering various update scenarios and validation cases.

**API & Resolver Enhancements:**

* Added a new `updateCard` GraphQL mutation to the `CardsResolver`, allowing users to update a card's title and/or description with appropriate authentication and validation.
* Introduced a new `UpdateCardInput` input type with validation for the update mutation.

**Service Layer & Validation:**

* Implemented the `updateCard` method in `CardsService`, including validation for card existence, workspace membership, and field-level validation (e.g., non-empty title). The method supports partial updates and returns the updated card or throws appropriate exceptions.

**Testing Improvements:**

* Added extensive unit tests for `CardsService.updateCard`, covering successful updates (title, description, both, or none), as well as edge cases such as missing/invalid IDs, empty titles, non-existent cards, and unauthorized access.
* Added new tests for the `CardsResolver` to verify correct mutation behavior and argument handling for various update scenarios.

**Supporting Changes:**

* Updated test mocks to support the new update functionality in both resolver and service tests. [[1]](diffhunk://#diff-26a58aec271f24c65949c12b94eb8a4392387b91792c50e69e8897ed6bc47031R14-R15) [[2]](diffhunk://#diff-fc43a6210fe94cd1ff6ed00585a83932089c2ea8fc30464d531c3fa810d5c793R8)