### PR TITLE
Add archiveCard mutation

### DIFF
--- a/backend/prisma/migrations/20260204110535_add_archived_to_card/migration.sql
+++ b/backend/prisma/migrations/20260204110535_add_archived_to_card/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Card" ADD COLUMN     "archived" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "archivedPosition" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -51,14 +51,16 @@ model List {
 }
 
 model Card {
-  id          String   @id @default(uuid())
-  title       String
-  description String?
-  position    Int      @default(0)
-  listId      String
-  list        List     @relation(fields: [listId], references: [id], onDelete: Cascade)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id              String   @id @default(uuid())
+  title           String
+  description     String?
+  position        Int      @default(0)
+  archived        Boolean  @default(false)
+  archivedPosition Int?    // Store original position when archived
+  listId          String
+  list            List     @relation(fields: [listId], references: [id], onDelete: Cascade)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@index([listId])
 }

--- a/backend/src/boards/models/card.model.ts
+++ b/backend/src/boards/models/card.model.ts
@@ -14,6 +14,12 @@ export class CardModel {
   @Field(() => Int)
   position!: number;
 
+  @Field(() => Boolean)
+  archived!: boolean;
+
+  @Field(() => Int, { nullable: true })
+  archivedPosition?: number | null;
+
   @Field(() => ID)
   listId!: string;
 

--- a/backend/src/cards/cards.resolver.spec.ts
+++ b/backend/src/cards/cards.resolver.spec.ts
@@ -6,6 +6,7 @@ describe('CardsResolver', () => {
   const cardsService = {
     createCard: jest.fn(),
     updateCard: jest.fn(),
+    archiveCard: jest.fn(),
   } as unknown as CardsService;
   const resolver = new CardsResolver(cardsService);
 
@@ -96,6 +97,50 @@ describe('CardsResolver', () => {
 
     expect(cardsService.updateCard).toHaveBeenCalledWith('card-1', 'user-1', undefined, 'New description');
     expect(result).toBe(updatedCard);
+  });
+
+  it('archives a card for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'card-1', archived: true };
+    const archivedCard = {
+      id: 'card-1',
+      title: 'My Card',
+      description: null,
+      position: 1,
+      archived: true,
+      archivedPosition: 1,
+      listId: 'list-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    cardsService.archiveCard = jest.fn().mockResolvedValue(archivedCard);
+
+    const result = await resolver.archiveCard(input, user);
+
+    expect(cardsService.archiveCard).toHaveBeenCalledWith('card-1', true, 'user-1');
+    expect(result).toBe(archivedCard);
+  });
+
+  it('unarchives a card for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'card-1', archived: false };
+    const unarchivedCard = {
+      id: 'card-1',
+      title: 'My Card',
+      description: null,
+      position: 1,
+      archived: false,
+      archivedPosition: null,
+      listId: 'list-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    cardsService.archiveCard = jest.fn().mockResolvedValue(unarchivedCard);
+
+    const result = await resolver.archiveCard(input, user);
+
+    expect(cardsService.archiveCard).toHaveBeenCalledWith('card-1', false, 'user-1');
+    expect(result).toBe(unarchivedCard);
   });
 });
 

--- a/backend/src/cards/cards.resolver.ts
+++ b/backend/src/cards/cards.resolver.ts
@@ -3,6 +3,7 @@ import { User } from '@prisma/client';
 import { AuthGuard } from '../common/guards/gql-auth.decorator';
 import { CreateCardInput } from './dto/create-card.input';
 import { UpdateCardInput } from './dto/update-card.input';
+import { ArchiveCardInput } from './dto/archive-card.input';
 import { CardModel } from '../boards/models/card.model';
 import { CardsService } from './cards.service';
 
@@ -26,6 +27,15 @@ export class CardsResolver {
     @Context('user') user: User
   ) {
     return this.cardsService.updateCard(input.id, user.id, input.title, input.description);
+  }
+
+  @Mutation(() => CardModel)
+  @AuthGuard()
+  async archiveCard(
+    @Args('input', { type: () => ArchiveCardInput }) input: ArchiveCardInput,
+    @Context('user') user: User
+  ) {
+    return this.cardsService.archiveCard(input.id, input.archived, user.id);
   }
 }
 

--- a/backend/src/cards/cards.service.spec.ts
+++ b/backend/src/cards/cards.service.spec.ts
@@ -13,7 +13,9 @@ describe('CardsService', () => {
       create: jest.fn(),
       findUnique: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
     },
+    $transaction: jest.fn(),
   } as unknown as PrismaService;
   const workspacesService = {
     requireWorkspaceAccess: jest.fn(),
@@ -580,6 +582,301 @@ describe('CardsService', () => {
         'user-2'
       );
       expect(prisma.card.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('archiveCard', () => {
+    it('archives a card and reorganizes positions when user is a workspace member and archived is true', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 1,
+        archived: false,
+        archivedPosition: null,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      const archivedCard = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 1,
+        archived: true,
+        archivedPosition: 1, // Original position stored
+        listId: 'list-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        list: cardWithList.list,
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithList)
+        .mockResolvedValueOnce(archivedCard);
+      prisma.$transaction = jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          card: {
+            update: jest.fn().mockResolvedValue(archivedCard),
+            updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+          },
+        };
+        return callback(tx);
+      });
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.archiveCard('card-1', true, 'user-1');
+
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(result).toBe(archivedCard);
+      expect(result?.archived).toBe(true);
+    });
+
+    it('unarchives a card and restores it to its original position when user is a workspace member and archived is false', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        archived: true,
+        archivedPosition: 1, // Original position was 1
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      const unarchivedCard = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 1,
+        archived: false,
+        archivedPosition: null,
+        listId: 'list-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        list: cardWithList.list,
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithList)
+        .mockResolvedValueOnce(unarchivedCard);
+      prisma.$transaction = jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          card: {
+            updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+            update: jest.fn().mockResolvedValue(unarchivedCard),
+          },
+        };
+        return callback(tx);
+      });
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.archiveCard('card-1', false, 'user-1');
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(result).toBe(unarchivedCard);
+      expect(result?.archived).toBe(false);
+      expect(result?.position).toBe(1); // Restored to original position
+    });
+
+    it('throws NotFoundException when cardId is empty', async () => {
+      await expect(service.archiveCard('', true, 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when cardId is whitespace only', async () => {
+      await expect(service.archiveCard('   ', true, 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when card does not exist', async () => {
+      prisma.card.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.archiveCard('card-1', true, 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        archived: false,
+        archivedPosition: null,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.archiveCard('card-1', true, 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when card is already archived and archived is true', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        archived: true,
+        archivedPosition: 0,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.archiveCard('card-1', true, 'user-1');
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(prisma.card.updateMany).not.toHaveBeenCalled();
+      expect(prisma.card.update).not.toHaveBeenCalled();
+      expect(result).toBe(cardWithList);
+    });
+
+    it('does nothing when card is already unarchived and archived is false', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        archived: false,
+        archivedPosition: null,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.archiveCard('card-1', false, 'user-1');
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(prisma.card.updateMany).not.toHaveBeenCalled();
+      expect(prisma.card.update).not.toHaveBeenCalled();
+      expect(result).toBe(cardWithList);
     });
   });
 });

--- a/backend/src/cards/cards.service.ts
+++ b/backend/src/cards/cards.service.ts
@@ -135,5 +135,124 @@ export class CardsService {
       },
     });
   }
+
+  async archiveCard(cardId: string, archived: boolean, userId: string) {
+    // Validate cardId is provided
+    if (!cardId || cardId.trim() === '') {
+      throw new NotFoundException('Card ID is required');
+    }
+
+    // Find the card with its list, board and workspace
+    const card = await this.prisma.card.findUnique({
+      where: { id: cardId },
+      include: {
+        list: {
+          include: {
+            board: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new NotFoundException('Card not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(
+      card.list.board.workspaceId,
+      userId
+    );
+
+    // Use a transaction to update archived status and reorganize positions if archiving
+    if (archived && !card.archived) {
+      // Archiving: store original position and reorganize positions of non-archived cards after this one
+      await this.prisma.$transaction(async (tx) => {
+        // Update the card archived status and store original position
+        await tx.card.update({
+          where: { id: cardId },
+          data: {
+            archived: true,
+            archivedPosition: card.position, // Store original position
+          },
+        });
+
+        // Reorganize positions: decrement positions of all non-archived cards after the archived one
+        await tx.card.updateMany({
+          where: {
+            listId: card.listId,
+            archived: false,
+            position: {
+              gt: card.position,
+            },
+          },
+          data: {
+            position: {
+              decrement: 1,
+            },
+          },
+        });
+      });
+
+      // Return the updated card
+      return this.prisma.card.findUnique({
+        where: { id: cardId },
+        include: {
+          list: true,
+        },
+      });
+    } else if (!archived && card.archived) {
+      // Unarchiving: restore original position and reorganize other cards
+      const originalPosition = card.archivedPosition ?? 0;
+
+      await this.prisma.$transaction(async (tx) => {
+        // First, increment positions of all non-archived cards at or after the original position
+        await tx.card.updateMany({
+          where: {
+            listId: card.listId,
+            archived: false,
+            position: {
+              gte: originalPosition,
+            },
+          },
+          data: {
+            position: {
+              increment: 1,
+            },
+          },
+        });
+
+        // Then restore the card to its original position
+        await tx.card.update({
+          where: { id: cardId },
+          data: {
+            archived: false,
+            position: originalPosition,
+            archivedPosition: null, // Clear archived position
+          },
+        });
+      });
+
+      // Return the updated card
+      return this.prisma.card.findUnique({
+        where: { id: cardId },
+        include: {
+          list: true,
+        },
+      });
+    } else {
+      // No change in archived status, just return the card
+      return this.prisma.card.findUnique({
+        where: { id: cardId },
+        include: {
+          list: true,
+        },
+      });
+    }
+  }
 }
 

--- a/backend/src/cards/dto/archive-card.input.ts
+++ b/backend/src/cards/dto/archive-card.input.ts
@@ -1,0 +1,15 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+
+@InputType()
+export class ArchiveCardInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @Field(() => Boolean)
+  @IsBoolean()
+  archived!: boolean;
+}
+


### PR DESCRIPTION
This pull request introduces the ability to archive and unarchive cards, along with all necessary schema, model, service, and resolver changes. It ensures that when a card is archived, its position is stored and other cards are reorganized; when unarchived, the card is restored to its original position. The changes are thoroughly tested with new unit tests to cover various scenarios.

**Archiving Feature Implementation:**

* Added `archived` (boolean) and `archivedPosition` (integer) fields to the `Card` table in the database and updated the Prisma schema and GraphQL model accordingly. (`backend/prisma/migrations/20260204110535_add_archived_to_card/migration.sql`, `backend/prisma/schema.prisma`, `backend/src/boards/models/card.model.ts`) [[1]](diffhunk://#diff-e3e55f5aa8b3cd536305263a4e10c376e7e1363c1d3372c690360a706fbdb5e9R1-R3) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR58-R59) [[3]](diffhunk://#diff-859e7436b3c7de1d9392ec570ebdafe0f3865e46b076769e34945db805525d12R17-R22)
* Created a new input DTO `ArchiveCardInput` for archiving/unarchiving cards via GraphQL. (`backend/src/cards/dto/archive-card.input.ts`)
* Added the `archiveCard` mutation to the `CardsResolver`, allowing clients to archive or unarchive a card. (`backend/src/cards/cards.resolver.ts`) [[1]](diffhunk://#diff-91bf8e3a44a6ffe8c05f7feba0e8d798fc117ed53bc3f291eaa86a1f0f6108cdR6) [[2]](diffhunk://#diff-91bf8e3a44a6ffe8c05f7feba0e8d798fc117ed53bc3f291eaa86a1f0f6108cdR31-R39)

**Service Logic and Tests:**

* Implemented `archiveCard` method in `CardsService`, handling archiving/unarchiving logic, position reorganization, and access control. (`backend/src/cards/cards.service.ts`)
* Added comprehensive unit tests for archiving and unarchiving scenarios, including position management and error cases. (`backend/src/cards/cards.service.spec.ts`, `backend/src/cards/cards.resolver.spec.ts`) [[1]](diffhunk://#diff-26a58aec271f24c65949c12b94eb8a4392387b91792c50e69e8897ed6bc47031R16-R18) [[2]](diffhunk://#diff-26a58aec271f24c65949c12b94eb8a4392387b91792c50e69e8897ed6bc47031R587-R881) [[3]](diffhunk://#diff-fc43a6210fe94cd1ff6ed00585a83932089c2ea8fc30464d531c3fa810d5c793R9) [[4]](diffhunk://#diff-fc43a6210fe94cd1ff6ed00585a83932089c2ea8fc30464d531c3fa810d5c793R101-R144)