### PR TITLE
Add deleteCard mutation

### DIFF
--- a/backend/src/cards/cards.resolver.spec.ts
+++ b/backend/src/cards/cards.resolver.spec.ts
@@ -7,6 +7,7 @@ describe('CardsResolver', () => {
     createCard: jest.fn(),
     updateCard: jest.fn(),
     archiveCard: jest.fn(),
+    deleteCard: jest.fn(),
   } as unknown as CardsService;
   const resolver = new CardsResolver(cardsService);
 
@@ -141,6 +142,16 @@ describe('CardsResolver', () => {
 
     expect(cardsService.archiveCard).toHaveBeenCalledWith('card-1', false, 'user-1');
     expect(result).toBe(unarchivedCard);
+  });
+
+  it('deletes a card for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    cardsService.deleteCard = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.deleteCard('card-1', user);
+
+    expect(cardsService.deleteCard).toHaveBeenCalledWith('card-1', 'user-1');
+    expect(result).toBe(true);
   });
 });
 

--- a/backend/src/cards/cards.resolver.ts
+++ b/backend/src/cards/cards.resolver.ts
@@ -37,5 +37,11 @@ export class CardsResolver {
   ) {
     return this.cardsService.archiveCard(input.id, input.archived, user.id);
   }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async deleteCard(@Args('id') id: string, @Context('user') user: User) {
+    return this.cardsService.deleteCard(id, user.id);
+  }
 }
 

--- a/backend/src/cards/cards.service.spec.ts
+++ b/backend/src/cards/cards.service.spec.ts
@@ -879,5 +879,193 @@ describe('CardsService', () => {
       expect(result).toBe(cardWithList);
     });
   });
+
+  describe('deleteCard', () => {
+    it('deletes a card and reorganizes positions when user is a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 1,
+        archived: false,
+        archivedPosition: null,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      prisma.$transaction = jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          card: {
+            delete: jest.fn().mockResolvedValue(cardWithList),
+            updateMany: jest.fn().mockResolvedValue({ count: 2 }),
+          },
+        };
+        return callback(tx);
+      });
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.deleteCard('card-1', 'user-1');
+
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('deletes a card at the end without reorganizing when user is a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 2,
+        archived: false,
+        archivedPosition: null,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      prisma.$transaction = jest.fn().mockImplementation(async (callback) => {
+        const tx = {
+          card: {
+            delete: jest.fn().mockResolvedValue(cardWithList),
+            updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          },
+        };
+        return callback(tx);
+      });
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.deleteCard('card-1', 'user-1');
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when cardId is empty', async () => {
+      await expect(service.deleteCard('', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when cardId is whitespace only', async () => {
+      await expect(service.deleteCard('   ', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when card does not exist', async () => {
+      prisma.card.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.deleteCard('card-1', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        description: null,
+        position: 0,
+        archived: false,
+        archivedPosition: null,
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.deleteCard('card-1', 'user-2')).rejects.toThrow(ForbiddenException);
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
 });
 

--- a/backend/src/cards/cards.service.ts
+++ b/backend/src/cards/cards.service.ts
@@ -254,5 +254,63 @@ export class CardsService {
       });
     }
   }
+
+  async deleteCard(cardId: string, userId: string) {
+    // Validate cardId is provided
+    if (!cardId || cardId.trim() === '') {
+      throw new NotFoundException('Card ID is required');
+    }
+
+    // Find the card with its list, board and workspace
+    const card = await this.prisma.card.findUnique({
+      where: { id: cardId },
+      include: {
+        list: {
+          include: {
+            board: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new NotFoundException('Card not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(
+      card.list.board.workspaceId,
+      userId
+    );
+
+    // Use a transaction to delete the card and reorganize positions
+    await this.prisma.$transaction(async (tx) => {
+      // Delete the card
+      await tx.card.delete({
+        where: { id: cardId },
+      });
+
+      // Reorganize positions: decrement positions of all cards after the deleted one in the same list
+      await tx.card.updateMany({
+        where: {
+          listId: card.listId,
+          position: {
+            gt: card.position,
+          },
+        },
+        data: {
+          position: {
+            decrement: 1,
+          },
+        },
+      });
+    });
+
+    return true;
+  }
 }
 


### PR DESCRIPTION
This pull request adds support for deleting cards, including all necessary backend logic, GraphQL resolver, and comprehensive tests. The new functionality ensures that only workspace members can delete cards, and properly reorganizes card positions within lists after deletion. Error handling is robust, covering cases such as missing or invalid card IDs, non-existent cards, and unauthorized users.

**Card Deletion Feature:**

* Added a `deleteCard` method to the `CardsService` that validates input, checks workspace membership, deletes the card, and reorganizes the positions of remaining cards in the list using a database transaction. Proper exceptions are thrown for invalid or unauthorized actions.
* Introduced the `deleteCard` mutation in the `CardsResolver`, allowing authenticated users to delete cards via GraphQL.

**Testing Enhancements:**

* Added comprehensive unit tests for `CardsService.deleteCard`, covering successful deletions (with and without position reorganization), as well as all relevant error cases (missing card ID, card not found, and forbidden access).
* Added a test for the `CardsResolver.deleteCard` mutation to ensure correct integration with the service and proper parameter passing.
* Mocked the `deleteCard` method in the resolver tests to support the new mutation.