### PR TITLE
Add addComment mutation

### DIFF
--- a/backend/prisma/migrations/20260204181413_add_comment_model/migration.sql
+++ b/backend/prisma/migrations/20260204181413_add_comment_model/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "Comment" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "cardId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Comment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Comment_cardId_idx" ON "Comment"("cardId");
+
+-- CreateIndex
+CREATE INDEX "Comment_authorId_idx" ON "Comment"("authorId");
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_cardId_fkey" FOREIGN KEY ("cardId") REFERENCES "Card"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   boards    Board[]
   ownedWorkspaces Workspace[] @relation("WorkspaceOwner")
   workspaceMemberships WorkspaceMember[]
+  comments  Comment[]
 }
 
 model Board {
@@ -59,10 +60,25 @@ model Card {
   archivedPosition Int?    // Store original position when archived
   listId          String
   list            List     @relation(fields: [listId], references: [id], onDelete: Cascade)
+  comments        Comment[]
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
   @@index([listId])
+}
+
+model Comment {
+  id        String   @id @default(uuid())
+  content   String
+  cardId    String
+  card      Card     @relation(fields: [cardId], references: [id], onDelete: Cascade)
+  authorId  String
+  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([cardId])
+  @@index([authorId])
 }
 
 enum WorkspaceRole {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { WorkspacesModule } from './workspaces/workspaces.module';
 import { BoardsModule } from './boards/boards.module';
 import { ListsModule } from './lists/lists.module';
 import { CardsModule } from './cards/cards.module';
+import { CommentsModule } from './comments/comments.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { CardsModule } from './cards/cards.module';
     BoardsModule,
     ListsModule,
     CardsModule,
+    CommentsModule,
     HealthModule,
   ],
 })

--- a/backend/src/comments/comments.module.ts
+++ b/backend/src/comments/comments.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { CommentsService } from './comments.service';
+import { CommentsResolver } from './comments.resolver';
+
+@Module({
+  imports: [PrismaModule, AuthModule, WorkspacesModule],
+  providers: [CommentsService, CommentsResolver],
+  exports: [CommentsService],
+})
+export class CommentsModule {}
+

--- a/backend/src/comments/comments.resolver.spec.ts
+++ b/backend/src/comments/comments.resolver.spec.ts
@@ -1,0 +1,45 @@
+import { User } from '@prisma/client';
+import { CommentsResolver } from './comments.resolver';
+import { CommentsService } from './comments.service';
+
+describe('CommentsResolver', () => {
+  const commentsService = {
+    addComment: jest.fn(),
+  } as unknown as CommentsService;
+  const resolver = new CommentsResolver(commentsService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds a comment for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { cardId: 'card-1', content: 'This is a comment' };
+    const comment = {
+      id: 'comment-1',
+      content: 'This is a comment',
+      cardId: 'card-1',
+      authorId: 'user-1',
+      author: {
+        id: 'user-1',
+        username: 'testuser',
+        email: 'test@example.com',
+        avatar: null,
+        createdAt: new Date(),
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    commentsService.addComment = jest.fn().mockResolvedValue(comment);
+
+    const result = await resolver.addComment(input, user);
+
+    expect(commentsService.addComment).toHaveBeenCalledWith(
+      'card-1',
+      'This is a comment',
+      'user-1'
+    );
+    expect(result).toBe(comment);
+  });
+});
+

--- a/backend/src/comments/comments.resolver.ts
+++ b/backend/src/comments/comments.resolver.ts
@@ -1,0 +1,21 @@
+import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
+import { User } from '@prisma/client';
+import { AuthGuard } from '../common/guards/gql-auth.decorator';
+import { AddCommentInput } from './dto/add-comment.input';
+import { CommentModel } from './models/comment.model';
+import { CommentsService } from './comments.service';
+
+@Resolver(() => CommentModel)
+export class CommentsResolver {
+  constructor(private readonly commentsService: CommentsService) {}
+
+  @Mutation(() => CommentModel)
+  @AuthGuard()
+  async addComment(
+    @Args('input', { type: () => AddCommentInput }) input: AddCommentInput,
+    @Context('user') user: User
+  ) {
+    return this.commentsService.addComment(input.cardId, input.content, user.id);
+  }
+}
+

--- a/backend/src/comments/comments.service.spec.ts
+++ b/backend/src/comments/comments.service.spec.ts
@@ -1,0 +1,258 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+import { CommentsService } from './comments.service';
+
+describe('CommentsService', () => {
+  const prisma = {
+    card: {
+      findUnique: jest.fn(),
+    },
+    comment: {
+      create: jest.fn(),
+    },
+  } as unknown as PrismaService;
+  const workspacesService = {
+    requireWorkspaceAccess: jest.fn(),
+  } as unknown as WorkspacesService;
+  const service = new CommentsService(prisma, workspacesService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('addComment', () => {
+    it('creates a comment when user is a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      const newComment = {
+        id: 'comment-1',
+        content: 'This is a comment',
+        cardId: 'card-1',
+        authorId: 'user-1',
+        author: {
+          id: 'user-1',
+          username: 'testuser',
+          email: 'test@example.com',
+          avatar: null,
+          createdAt: new Date(),
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      prisma.comment.create = jest.fn().mockResolvedValue(newComment);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.addComment('card-1', 'This is a comment', 'user-1');
+
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.comment.create).toHaveBeenCalledWith({
+        data: {
+          content: 'This is a comment',
+          cardId: 'card-1',
+          authorId: 'user-1',
+        },
+        include: {
+          author: true,
+        },
+      });
+      expect(result).toBe(newComment);
+      expect(result.content).toBe('This is a comment');
+      expect(result.authorId).toBe('user-1');
+    });
+
+    it('trims content whitespace when creating a comment', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      const newComment = {
+        id: 'comment-1',
+        content: 'This is a comment',
+        cardId: 'card-1',
+        authorId: 'user-1',
+        author: {
+          id: 'user-1',
+          username: 'testuser',
+          email: 'test@example.com',
+          avatar: null,
+          createdAt: new Date(),
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      prisma.comment.create = jest.fn().mockResolvedValue(newComment);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.addComment('card-1', '  This is a comment  ', 'user-1');
+
+      expect(prisma.comment.create).toHaveBeenCalledWith({
+        data: {
+          content: 'This is a comment',
+          cardId: 'card-1',
+          authorId: 'user-1',
+        },
+        include: {
+          author: true,
+        },
+      });
+      expect(result).toBe(newComment);
+    });
+
+    it('throws NotFoundException when cardId is empty', async () => {
+      await expect(service.addComment('', 'This is a comment', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.comment.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when cardId is whitespace only', async () => {
+      await expect(service.addComment('   ', 'This is a comment', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.comment.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when content is empty', async () => {
+      await expect(service.addComment('card-1', '', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.comment.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when content is whitespace only', async () => {
+      await expect(service.addComment('card-1', '   ', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.comment.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when card does not exist', async () => {
+      prisma.card.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.addComment('card-1', 'This is a comment', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.comment.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const cardWithList = {
+        id: 'card-1',
+        title: 'My Card',
+        listId: 'list-1',
+        list: {
+          id: 'list-1',
+          title: 'My List',
+          boardId: 'board-1',
+          board: {
+            id: 'board-1',
+            title: 'My Board',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+          },
+        },
+      };
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.addComment('card-1', 'This is a comment', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.comment.create).not.toHaveBeenCalled();
+    });
+  });
+});
+

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -1,0 +1,62 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+
+@Injectable()
+export class CommentsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly workspacesService: WorkspacesService
+  ) {}
+
+  async addComment(cardId: string, content: string, userId: string) {
+    // Validate cardId is provided
+    if (!cardId || cardId.trim() === '') {
+      throw new NotFoundException('Card ID is required');
+    }
+
+    // Validate content is provided
+    if (!content || content.trim() === '') {
+      throw new NotFoundException('Content is required');
+    }
+
+    // Find the card with its list, board and workspace
+    const card = await this.prisma.card.findUnique({
+      where: { id: cardId },
+      include: {
+        list: {
+          include: {
+            board: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new NotFoundException('Card not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(
+      card.list.board.workspaceId,
+      userId
+    );
+
+    // Create the comment
+    return this.prisma.comment.create({
+      data: {
+        content: content.trim(),
+        cardId,
+        authorId: userId,
+      },
+      include: {
+        author: true,
+      },
+    });
+  }
+}
+

--- a/backend/src/comments/dto/add-comment.input.ts
+++ b/backend/src/comments/dto/add-comment.input.ts
@@ -1,0 +1,16 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class AddCommentInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  cardId!: string;
+
+  @Field()
+  @IsString()
+  @MinLength(1)
+  content!: string;
+}
+

--- a/backend/src/comments/models/comment.model.ts
+++ b/backend/src/comments/models/comment.model.ts
@@ -1,0 +1,27 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { UserModel } from '../../users/models/user.model';
+
+@ObjectType()
+export class CommentModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  content!: string;
+
+  @Field(() => ID)
+  cardId!: string;
+
+  @Field(() => ID)
+  authorId!: string;
+
+  @Field(() => UserModel)
+  author!: UserModel;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+


### PR DESCRIPTION
This pull request introduces a new comment feature for cards, allowing users to add comments to cards within workspaces. The implementation includes database schema changes, GraphQL API additions, service logic for comment creation, and comprehensive tests to ensure correct behavior and access control.

**Database and Model Changes**
* Added a new `Comment` table to the database schema, including indexes and foreign key relationships to `Card` and `User` for efficient querying and referential integrity.
* Updated Prisma models in `schema.prisma` to define the `Comment` model and establish relations with `User` and `Card` models. [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR22) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR63-R83)

**Backend API and Service Implementation**
* Created a new `CommentsModule` with resolver, service, and DTO/model definitions to support adding comments via GraphQL mutations. [[1]](diffhunk://#diff-8ab0f398513a8b05e67d63ebbcba1555bd18dfd11210b7de0b476cff8b3bc26eR1-R14) [[2]](diffhunk://#diff-c4002b34a6720cf207721f6f260cc1ed00e72659e58ef2c4f9c7bd66f0d25d2fR1-R16) [[3]](diffhunk://#diff-70100a0dda2b1100835612fe2f4cd910c20d00ba0edcfc57a7a85229189d046aR1-R27) [[4]](diffhunk://#diff-b4dabfa3e5e38ed279f0b512463e6b7c04022b3c16bdce778ab78bcc3f739da5R1-R21)
* Implemented the `CommentsService` to handle comment creation, including input validation, workspace membership checks, and association with cards and authors.

**Testing**
* Added unit tests for both the resolver and service to verify correct comment creation, input validation, workspace access control, and error handling for edge cases. [[1]](diffhunk://#diff-51dbb1a327753903d481c2a9c7457e49ed592bc9306deaaaa6264b34277cbd0cR1-R45) [[2]](diffhunk://#diff-2b79587fe0513e533a02e30ecfa86b877d57f8e7e1c11b7103c1650d9824f255R1-R258)

**Module Integration**
* Registered the new `CommentsModule` in the main application module to enable comment functionality throughout the backend. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R15) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R38)