### PR TITLE
Add deleteComment mutation

### DIFF
--- a/backend/src/comments/comments.resolver.spec.ts
+++ b/backend/src/comments/comments.resolver.spec.ts
@@ -5,6 +5,7 @@ import { CommentsService } from './comments.service';
 describe('CommentsResolver', () => {
   const commentsService = {
     addComment: jest.fn(),
+    deleteComment: jest.fn(),
   } as unknown as CommentsService;
   const resolver = new CommentsResolver(commentsService);
 
@@ -40,6 +41,16 @@ describe('CommentsResolver', () => {
       'user-1'
     );
     expect(result).toBe(comment);
+  });
+
+  it('deletes a comment for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    commentsService.deleteComment = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.deleteComment('comment-1', user);
+
+    expect(commentsService.deleteComment).toHaveBeenCalledWith('comment-1', 'user-1');
+    expect(result).toBe(true);
   });
 });
 

--- a/backend/src/comments/comments.resolver.ts
+++ b/backend/src/comments/comments.resolver.ts
@@ -17,5 +17,11 @@ export class CommentsResolver {
   ) {
     return this.commentsService.addComment(input.cardId, input.content, user.id);
   }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async deleteComment(@Args('id') id: string, @Context('user') user: User) {
+    return this.commentsService.deleteComment(id, user.id);
+  }
 }
 

--- a/backend/src/comments/comments.service.spec.ts
+++ b/backend/src/comments/comments.service.spec.ts
@@ -10,6 +10,8 @@ describe('CommentsService', () => {
     },
     comment: {
       create: jest.fn(),
+      findUnique: jest.fn(),
+      delete: jest.fn(),
     },
   } as unknown as PrismaService;
   const workspacesService = {
@@ -252,6 +254,219 @@ describe('CommentsService', () => {
         'user-2'
       );
       expect(prisma.comment.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('deletes a comment when user is the author', async () => {
+      const commentWithCard = {
+        id: 'comment-1',
+        content: 'This is a comment',
+        cardId: 'card-1',
+        authorId: 'user-1',
+        author: {
+          id: 'user-1',
+          username: 'testuser',
+          email: 'test@example.com',
+        },
+        card: {
+          id: 'card-1',
+          title: 'My Card',
+          listId: 'list-1',
+          list: {
+            id: 'list-1',
+            title: 'My List',
+            boardId: 'board-1',
+            board: {
+              id: 'board-1',
+              title: 'My Board',
+              workspaceId: 'workspace-1',
+              workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-2' },
+            },
+          },
+        },
+      };
+      prisma.comment.findUnique = jest.fn().mockResolvedValue(commentWithCard);
+      prisma.comment.delete = jest.fn().mockResolvedValue(commentWithCard);
+
+      const result = await service.deleteComment('comment-1', 'user-1');
+
+      expect(prisma.comment.findUnique).toHaveBeenCalledWith({
+        where: { id: 'comment-1' },
+        include: {
+          author: true,
+          card: {
+            include: {
+              list: {
+                include: {
+                  board: {
+                    include: {
+                      workspace: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(prisma.comment.delete).toHaveBeenCalledWith({
+        where: { id: 'comment-1' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('deletes a comment when user is the workspace owner', async () => {
+      const commentWithCard = {
+        id: 'comment-1',
+        content: 'This is a comment',
+        cardId: 'card-1',
+        authorId: 'user-2',
+        author: {
+          id: 'user-2',
+          username: 'author',
+          email: 'author@example.com',
+        },
+        card: {
+          id: 'card-1',
+          title: 'My Card',
+          listId: 'list-1',
+          list: {
+            id: 'list-1',
+            title: 'My List',
+            boardId: 'board-1',
+            board: {
+              id: 'board-1',
+              title: 'My Board',
+              workspaceId: 'workspace-1',
+              workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+            },
+          },
+        },
+      };
+      prisma.comment.findUnique = jest.fn().mockResolvedValue(commentWithCard);
+      prisma.comment.delete = jest.fn().mockResolvedValue(commentWithCard);
+
+      const result = await service.deleteComment('comment-1', 'user-1');
+
+      expect(prisma.comment.findUnique).toHaveBeenCalledWith({
+        where: { id: 'comment-1' },
+        include: {
+          author: true,
+          card: {
+            include: {
+              list: {
+                include: {
+                  board: {
+                    include: {
+                      workspace: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(prisma.comment.delete).toHaveBeenCalledWith({
+        where: { id: 'comment-1' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when commentId is empty', async () => {
+      await expect(service.deleteComment('', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.comment.findUnique).not.toHaveBeenCalled();
+      expect(prisma.comment.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when commentId is whitespace only', async () => {
+      await expect(service.deleteComment('   ', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.comment.findUnique).not.toHaveBeenCalled();
+      expect(prisma.comment.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when comment does not exist', async () => {
+      prisma.comment.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.deleteComment('comment-1', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.comment.findUnique).toHaveBeenCalledWith({
+        where: { id: 'comment-1' },
+        include: {
+          author: true,
+          card: {
+            include: {
+              list: {
+                include: {
+                  board: {
+                    include: {
+                      workspace: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(prisma.comment.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is neither author nor workspace owner', async () => {
+      const commentWithCard = {
+        id: 'comment-1',
+        content: 'This is a comment',
+        cardId: 'card-1',
+        authorId: 'user-2',
+        author: {
+          id: 'user-2',
+          username: 'author',
+          email: 'author@example.com',
+        },
+        card: {
+          id: 'card-1',
+          title: 'My Card',
+          listId: 'list-1',
+          list: {
+            id: 'list-1',
+            title: 'My List',
+            boardId: 'board-1',
+            board: {
+              id: 'board-1',
+              title: 'My Board',
+              workspaceId: 'workspace-1',
+              workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-3' },
+            },
+          },
+        },
+      };
+      prisma.comment.findUnique = jest.fn().mockResolvedValue(commentWithCard);
+
+      await expect(service.deleteComment('comment-1', 'user-1')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.comment.findUnique).toHaveBeenCalledWith({
+        where: { id: 'comment-1' },
+        include: {
+          author: true,
+          card: {
+            include: {
+              list: {
+                include: {
+                  board: {
+                    include: {
+                      workspace: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(prisma.comment.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -58,5 +58,54 @@ export class CommentsService {
       },
     });
   }
+
+  async deleteComment(commentId: string, userId: string) {
+    // Validate commentId is provided
+    if (!commentId || commentId.trim() === '') {
+      throw new NotFoundException('Comment ID is required');
+    }
+
+    // Find the comment with its author, card, list, board and workspace
+    const comment = await this.prisma.comment.findUnique({
+      where: { id: commentId },
+      include: {
+        author: true,
+        card: {
+          include: {
+            list: {
+              include: {
+                board: {
+                  include: {
+                    workspace: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!comment) {
+      throw new NotFoundException('Comment not found');
+    }
+
+    // Check if user is the author OR the workspace owner
+    const isAuthor = comment.authorId === userId;
+    const isWorkspaceOwner = comment.card.list.board.workspace.ownerId === userId;
+
+    if (!isAuthor && !isWorkspaceOwner) {
+      throw new ForbiddenException(
+        'Only the comment author or workspace owner can delete this comment'
+      );
+    }
+
+    // Delete the comment
+    await this.prisma.comment.delete({
+      where: { id: commentId },
+    });
+
+    return true;
+  }
 }
 


### PR DESCRIPTION
This pull request adds support for deleting comments, including authorization logic and comprehensive tests. The main changes introduce a new `deleteComment` mutation in the resolver, implement the corresponding service method with proper permission checks, and add extensive unit tests for various scenarios.

**Feature: Comment Deletion**

* Added a `deleteComment` method to `CommentsService` that allows a comment to be deleted only by its author or the workspace owner. The method includes validation for the comment ID, checks for existence, and enforces permissions, throwing appropriate exceptions otherwise. (`backend/src/comments/comments.service.ts`)
* Introduced a `deleteComment` mutation in `CommentsResolver` to expose comment deletion via GraphQL, guarded by authentication. (`backend/src/comments/comments.resolver.ts`)

**Testing: Unit Tests for Deletion**

* Added comprehensive unit tests for `deleteComment` in `CommentsService`, covering successful deletion by author and workspace owner, and error cases for missing/invalid IDs, non-existent comments, and unauthorized users. (`backend/src/comments/comments.service.spec.ts`)
* Updated the mock Prisma service to include the necessary `findUnique` and `delete` methods for comment deletion. (`backend/src/comments/comments.service.spec.ts`)
* Added a unit test for the new `deleteComment` mutation in `CommentsResolver`. (`backend/src/comments/comments.resolver.spec.ts`)
* Updated the resolver test setup to mock the new `deleteComment` method. (`backend/src/comments/comments.resolver.spec.ts`)