### PR TITLE
Add label CRUD operations

### DIFF
--- a/backend/prisma/migrations/20260204202810_add_label_model/migration.sql
+++ b/backend/prisma/migrations/20260204202810_add_label_model/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Label" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Label_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Label_workspaceId_idx" ON "Label"("workspaceId");
+
+-- AddForeignKey
+ALTER TABLE "Label" ADD CONSTRAINT "Label_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -93,6 +93,7 @@ model Workspace {
   owner     User     @relation("WorkspaceOwner", fields: [ownerId], references: [id], onDelete: Cascade)
   members   WorkspaceMember[]
   boards    Board[]
+  labels    Label[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -108,7 +109,16 @@ model WorkspaceMember {
   @@index([workspaceId])
 }
 
+model Label {
+  id          String   @id @default(uuid())
+  name        String
+  color       String
+  workspaceId String
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-
+  @@index([workspaceId])
+}
 
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { BoardsModule } from './boards/boards.module';
 import { ListsModule } from './lists/lists.module';
 import { CardsModule } from './cards/cards.module';
 import { CommentsModule } from './comments/comments.module';
+import { LabelsModule } from './labels/labels.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { CommentsModule } from './comments/comments.module';
     ListsModule,
     CardsModule,
     CommentsModule,
+    LabelsModule,
     HealthModule,
   ],
 })

--- a/backend/src/labels/dto/create-label.input.ts
+++ b/backend/src/labels/dto/create-label.input.ts
@@ -1,0 +1,21 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class CreateLabelInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  workspaceId!: string;
+
+  @Field()
+  @IsString()
+  @MinLength(1)
+  name!: string;
+
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  color!: string;
+}
+

--- a/backend/src/labels/dto/update-label.input.ts
+++ b/backend/src/labels/dto/update-label.input.ts
@@ -1,0 +1,23 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+
+@InputType()
+export class UpdateLabelInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsString()
+  @MinLength(1, { message: 'Name cannot be empty' })
+  name?: string | null;
+
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  color?: string | null;
+}
+

--- a/backend/src/labels/labels.module.ts
+++ b/backend/src/labels/labels.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { LabelsService } from './labels.service';
+import { LabelsResolver } from './labels.resolver';
+
+@Module({
+  imports: [PrismaModule, AuthModule, WorkspacesModule],
+  providers: [LabelsService, LabelsResolver],
+  exports: [LabelsService],
+})
+export class LabelsModule {}
+

--- a/backend/src/labels/labels.resolver.spec.ts
+++ b/backend/src/labels/labels.resolver.spec.ts
@@ -1,0 +1,118 @@
+import { User } from '@prisma/client';
+import { LabelsResolver } from './labels.resolver';
+import { LabelsService } from './labels.service';
+
+describe('LabelsResolver', () => {
+  const labelsService = {
+    createLabel: jest.fn(),
+    updateLabel: jest.fn(),
+    deleteLabel: jest.fn(),
+  } as unknown as LabelsService;
+  const resolver = new LabelsResolver(labelsService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a label for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { workspaceId: 'workspace-1', name: 'Bug', color: '#ff0000' };
+    const label = {
+      id: 'label-1',
+      name: 'Bug',
+      color: '#ff0000',
+      workspaceId: 'workspace-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    labelsService.createLabel = jest.fn().mockResolvedValue(label);
+
+    const result = await resolver.createLabel(input, user);
+
+    expect(labelsService.createLabel).toHaveBeenCalledWith(
+      'workspace-1',
+      'Bug',
+      '#ff0000',
+      'user-1'
+    );
+    expect(result).toBe(label);
+  });
+
+  it('updates a label for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'label-1', name: 'Updated Name', color: '#00ff00' };
+    const updatedLabel = {
+      id: 'label-1',
+      name: 'Updated Name',
+      color: '#00ff00',
+      workspaceId: 'workspace-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    labelsService.updateLabel = jest.fn().mockResolvedValue(updatedLabel);
+
+    const result = await resolver.updateLabel(input, user);
+
+    expect(labelsService.updateLabel).toHaveBeenCalledWith(
+      'label-1',
+      'user-1',
+      'Updated Name',
+      '#00ff00'
+    );
+    expect(result).toBe(updatedLabel);
+  });
+
+  it('updates a label with only name for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'label-1', name: 'Updated Name' };
+    const updatedLabel = {
+      id: 'label-1',
+      name: 'Updated Name',
+      color: '#ff0000',
+      workspaceId: 'workspace-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    labelsService.updateLabel = jest.fn().mockResolvedValue(updatedLabel);
+
+    const result = await resolver.updateLabel(input, user);
+
+    expect(labelsService.updateLabel).toHaveBeenCalledWith(
+      'label-1',
+      'user-1',
+      'Updated Name',
+      undefined
+    );
+    expect(result).toBe(updatedLabel);
+  });
+
+  it('updates a label with only color for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { id: 'label-1', color: '#00ff00' };
+    const updatedLabel = {
+      id: 'label-1',
+      name: 'Bug',
+      color: '#00ff00',
+      workspaceId: 'workspace-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    labelsService.updateLabel = jest.fn().mockResolvedValue(updatedLabel);
+
+    const result = await resolver.updateLabel(input, user);
+
+    expect(labelsService.updateLabel).toHaveBeenCalledWith('label-1', 'user-1', undefined, '#00ff00');
+    expect(result).toBe(updatedLabel);
+  });
+
+  it('deletes a label for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    labelsService.deleteLabel = jest.fn().mockResolvedValue(true);
+
+    const result = await resolver.deleteLabel('label-1', user);
+
+    expect(labelsService.deleteLabel).toHaveBeenCalledWith('label-1', 'user-1');
+    expect(result).toBe(true);
+  });
+});
+

--- a/backend/src/labels/labels.resolver.ts
+++ b/backend/src/labels/labels.resolver.ts
@@ -1,0 +1,37 @@
+import { Args, Context, Mutation, Resolver } from '@nestjs/graphql';
+import { User } from '@prisma/client';
+import { AuthGuard } from '../common/guards/gql-auth.decorator';
+import { CreateLabelInput } from './dto/create-label.input';
+import { UpdateLabelInput } from './dto/update-label.input';
+import { LabelModel } from './models/label.model';
+import { LabelsService } from './labels.service';
+
+@Resolver(() => LabelModel)
+export class LabelsResolver {
+  constructor(private readonly labelsService: LabelsService) {}
+
+  @Mutation(() => LabelModel)
+  @AuthGuard()
+  async createLabel(
+    @Args('input', { type: () => CreateLabelInput }) input: CreateLabelInput,
+    @Context('user') user: User
+  ) {
+    return this.labelsService.createLabel(input.workspaceId, input.name, input.color, user.id);
+  }
+
+  @Mutation(() => LabelModel)
+  @AuthGuard()
+  async updateLabel(
+    @Args('input', { type: () => UpdateLabelInput }) input: UpdateLabelInput,
+    @Context('user') user: User
+  ) {
+    return this.labelsService.updateLabel(input.id, user.id, input.name, input.color);
+  }
+
+  @Mutation(() => Boolean)
+  @AuthGuard()
+  async deleteLabel(@Args('id') id: string, @Context('user') user: User) {
+    return this.labelsService.deleteLabel(id, user.id);
+  }
+}
+

--- a/backend/src/labels/labels.service.spec.ts
+++ b/backend/src/labels/labels.service.spec.ts
@@ -1,0 +1,494 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+import { LabelsService } from './labels.service';
+
+describe('LabelsService', () => {
+  const prisma = {
+    label: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  } as unknown as PrismaService;
+  const workspacesService = {
+    requireWorkspaceAccess: jest.fn(),
+  } as unknown as WorkspacesService;
+  const service = new LabelsService(prisma, workspacesService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createLabel', () => {
+    it('creates a label when user is a workspace member', async () => {
+      const newLabel = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prisma.label.create = jest.fn().mockResolvedValue(newLabel);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.createLabel('workspace-1', 'Bug', '#ff0000', 'user-1');
+
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.label.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Bug',
+          color: '#ff0000',
+          workspaceId: 'workspace-1',
+        },
+      });
+      expect(result).toBe(newLabel);
+      expect(result.name).toBe('Bug');
+      expect(result.color).toBe('#ff0000');
+    });
+
+    it('trims name and color whitespace when creating a label', async () => {
+      const newLabel = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prisma.label.create = jest.fn().mockResolvedValue(newLabel);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.createLabel('workspace-1', '  Bug  ', '  #ff0000  ', 'user-1');
+
+      expect(prisma.label.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Bug',
+          color: '#ff0000',
+          workspaceId: 'workspace-1',
+        },
+      });
+      expect(result).toBe(newLabel);
+    });
+
+    it('throws NotFoundException when workspaceId is empty', async () => {
+      await expect(service.createLabel('', 'Bug', '#ff0000', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when workspaceId is whitespace only', async () => {
+      await expect(service.createLabel('   ', 'Bug', '#ff0000', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when name is empty', async () => {
+      await expect(service.createLabel('workspace-1', '', '#ff0000', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when name is whitespace only', async () => {
+      await expect(service.createLabel('workspace-1', '   ', '#ff0000', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when color is empty', async () => {
+      await expect(service.createLabel('workspace-1', 'Bug', '', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.create).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when color is whitespace only', async () => {
+      await expect(service.createLabel('workspace-1', 'Bug', '   ', 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.createLabel('workspace-1', 'Bug', '#ff0000', 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.label.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateLabel', () => {
+    it('updates a label name when user is a workspace member', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Old Name',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const updatedLabel = {
+        id: 'label-1',
+        name: 'New Name',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prisma.label.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(labelWithWorkspace)
+        .mockResolvedValueOnce(updatedLabel);
+      prisma.label.update = jest.fn().mockResolvedValue(updatedLabel);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateLabel('label-1', 'user-1', 'New Name', undefined);
+
+      expect(prisma.label.findUnique).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.label.update).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        data: {
+          name: 'New Name',
+        },
+      });
+      expect(result).toBe(updatedLabel);
+      expect(result?.name).toBe('New Name');
+    });
+
+    it('updates a label color when user is a workspace member', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const updatedLabel = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#00ff00',
+        workspaceId: 'workspace-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prisma.label.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(labelWithWorkspace)
+        .mockResolvedValueOnce(updatedLabel);
+      prisma.label.update = jest.fn().mockResolvedValue(updatedLabel);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateLabel('label-1', 'user-1', undefined, '#00ff00');
+
+      expect(prisma.label.update).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        data: {
+          color: '#00ff00',
+        },
+      });
+      expect(result).toBe(updatedLabel);
+      expect(result?.color).toBe('#00ff00');
+    });
+
+    it('updates both name and color when user is a workspace member', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Old Name',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      const updatedLabel = {
+        id: 'label-1',
+        name: 'New Name',
+        color: '#00ff00',
+        workspaceId: 'workspace-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prisma.label.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(labelWithWorkspace)
+        .mockResolvedValueOnce(updatedLabel);
+      prisma.label.update = jest.fn().mockResolvedValue(updatedLabel);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateLabel('label-1', 'user-1', 'New Name', '#00ff00');
+
+      expect(prisma.label.update).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        data: {
+          name: 'New Name',
+          color: '#00ff00',
+        },
+      });
+      expect(result).toBe(updatedLabel);
+      expect(result?.name).toBe('New Name');
+      expect(result?.color).toBe('#00ff00');
+    });
+
+    it('returns label as is when no fields are provided for update', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.label.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(labelWithWorkspace)
+        .mockResolvedValueOnce(labelWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.updateLabel('label-1', 'user-1', undefined, undefined);
+
+      expect(prisma.label.update).not.toHaveBeenCalled();
+      expect(prisma.label.findUnique).toHaveBeenCalledTimes(2);
+      expect(result).toBe(labelWithWorkspace);
+    });
+
+    it('throws NotFoundException when labelId is empty', async () => {
+      await expect(service.updateLabel('', 'user-1', 'New Name', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.label.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when labelId is whitespace only', async () => {
+      await expect(service.updateLabel('   ', 'user-1', 'New Name', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.label.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when name is empty string', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.label.findUnique = jest.fn().mockResolvedValue(labelWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      await expect(service.updateLabel('label-1', 'user-1', '', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.label.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when color is empty string', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.label.findUnique = jest.fn().mockResolvedValue(labelWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      await expect(service.updateLabel('label-1', 'user-1', undefined, '')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.label.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when label does not exist', async () => {
+      prisma.label.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.updateLabel('label-1', 'user-1', 'New Name', undefined)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.label.findUnique).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.update).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.label.findUnique = jest.fn().mockResolvedValue(labelWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.updateLabel('label-1', 'user-2', 'New Name', undefined)).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.label.findUnique).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.label.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteLabel', () => {
+    it('deletes a label when user is a workspace member', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.label.findUnique = jest.fn().mockResolvedValue(labelWithWorkspace);
+      prisma.label.delete = jest.fn().mockResolvedValue(labelWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.deleteLabel('label-1', 'user-1');
+
+      expect(prisma.label.findUnique).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.label.delete).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('throws NotFoundException when labelId is empty', async () => {
+      await expect(service.deleteLabel('', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.label.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when labelId is whitespace only', async () => {
+      await expect(service.deleteLabel('   ', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.label.findUnique).not.toHaveBeenCalled();
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when label does not exist', async () => {
+      prisma.label.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.deleteLabel('label-1', 'user-1')).rejects.toThrow(NotFoundException);
+      expect(prisma.label.findUnique).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).not.toHaveBeenCalled();
+      expect(prisma.label.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      const labelWithWorkspace = {
+        id: 'label-1',
+        name: 'Bug',
+        color: '#ff0000',
+        workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+      };
+      prisma.label.findUnique = jest.fn().mockResolvedValue(labelWithWorkspace);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.deleteLabel('label-1', 'user-2')).rejects.toThrow(ForbiddenException);
+      expect(prisma.label.findUnique).toHaveBeenCalledWith({
+        where: { id: 'label-1' },
+        include: {
+          workspace: true,
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-2'
+      );
+      expect(prisma.label.delete).not.toHaveBeenCalled();
+    });
+  });
+});
+

--- a/backend/src/labels/labels.service.ts
+++ b/backend/src/labels/labels.service.ts
@@ -1,0 +1,135 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
+
+@Injectable()
+export class LabelsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly workspacesService: WorkspacesService
+  ) {}
+
+  async createLabel(workspaceId: string, name: string, color: string, userId: string) {
+    // Validate workspaceId is provided
+    if (!workspaceId || workspaceId.trim() === '') {
+      throw new NotFoundException('Workspace ID is required');
+    }
+
+    // Validate name is provided
+    if (!name || name.trim() === '') {
+      throw new NotFoundException('Name is required');
+    }
+
+    // Validate color is provided
+    if (!color || color.trim() === '') {
+      throw new NotFoundException('Color is required');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(workspaceId, userId);
+
+    // Create the label
+    return this.prisma.label.create({
+      data: {
+        name: name.trim(),
+        color: color.trim(),
+        workspaceId,
+      },
+    });
+  }
+
+  async updateLabel(
+    labelId: string,
+    userId: string,
+    name?: string | null,
+    color?: string | null
+  ) {
+    // Validate labelId is provided
+    if (!labelId || labelId.trim() === '') {
+      throw new NotFoundException('Label ID is required');
+    }
+
+    // Find the label with its workspace
+    const label = await this.prisma.label.findUnique({
+      where: { id: labelId },
+      include: {
+        workspace: true,
+      },
+    });
+
+    if (!label) {
+      throw new NotFoundException('Label not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(label.workspaceId, userId);
+
+    // Prepare update data
+    const updateData: { name?: string; color?: string } = {};
+
+    if (name !== undefined) {
+      // If name is provided, validate it's not empty
+      if (name !== null && name.trim() === '') {
+        throw new NotFoundException('Name cannot be empty');
+      }
+      // Only include name if it's not null
+      if (name !== null) {
+        updateData.name = name.trim();
+      }
+    }
+
+    if (color !== undefined) {
+      // If color is provided, validate it's not empty
+      if (color !== null && color.trim() === '') {
+        throw new NotFoundException('Color cannot be empty');
+      }
+      // Only include color if it's not null
+      if (color !== null) {
+        updateData.color = color.trim();
+      }
+    }
+
+    // If no fields to update, return the label as is
+    if (Object.keys(updateData).length === 0) {
+      return this.prisma.label.findUnique({
+        where: { id: labelId },
+      });
+    }
+
+    // Update the label
+    return this.prisma.label.update({
+      where: { id: labelId },
+      data: updateData,
+    });
+  }
+
+  async deleteLabel(labelId: string, userId: string) {
+    // Validate labelId is provided
+    if (!labelId || labelId.trim() === '') {
+      throw new NotFoundException('Label ID is required');
+    }
+
+    // Find the label with its workspace
+    const label = await this.prisma.label.findUnique({
+      where: { id: labelId },
+      include: {
+        workspace: true,
+      },
+    });
+
+    if (!label) {
+      throw new NotFoundException('Label not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(label.workspaceId, userId);
+
+    // Delete the label
+    await this.prisma.label.delete({
+      where: { id: labelId },
+    });
+
+    return true;
+  }
+}
+

--- a/backend/src/labels/models/label.model.ts
+++ b/backend/src/labels/models/label.model.ts
@@ -1,0 +1,23 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class LabelModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  name!: string;
+
+  @Field()
+  color!: string;
+
+  @Field(() => ID)
+  workspaceId!: string;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+


### PR DESCRIPTION
This pull request introduces a new label management feature to the backend, allowing users to create, update, and delete labels within workspaces. The changes include updates to the database schema, GraphQL API, and service layer, along with tests to ensure correct functionality.

**Database and Model Changes:**

* Added a new `Label` table to the database schema, including fields for `id`, `name`, `color`, `workspaceId`, timestamps, and a foreign key relationship to `Workspace`.
* Updated the Prisma schema to define the `Label` model and its relation to `Workspace`, including an index on `workspaceId`. [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR96) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR112-R122)

**Backend API and Service Implementation:**

* Created the GraphQL DTOs (`CreateLabelInput` and `UpdateLabelInput`), model (`LabelModel`), resolver (`LabelsResolver`), and service (`LabelsService`) to handle label creation, updating, and deletion, with validation and access control. [[1]](diffhunk://#diff-a23965c62306186a6ed64c02f1ef2fe1564501a046937c0b0609fea02ee894e3R1-R21) [[2]](diffhunk://#diff-a804eaf0fc579a3483d77a93bf2d7f8a4df9a67d711d9e4c0a8882ad56c4e8c7R1-R23) [[3]](diffhunk://#diff-308bb3244d06a7ddc1ee123dac13079671ac257d532f7d681e8d8417044a9dbdR1-R37) [[4]](diffhunk://#diff-5b4300dc1dfa51299ae26da5c7f387199e8758ce63fd368db0d45a5e159616c0R1-R135) [[5]](diffhunk://#diff-878508492940fe67a56790a4c8c689a71f3f848d73e6e75e76bb1fb0fcb5e23cR1-R23)
* Registered the new `LabelsModule` in the main application module to enable label functionality throughout the backend. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R16) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R40) [[3]](diffhunk://#diff-3f04d20a2240c3b7dac1295ec9561fd29d0d169c0da4109dbbd7870ba2f42771R1-R14)

**Testing:**

* Added unit tests for the `LabelsResolver` to verify label creation, updating (with various field combinations), and deletion, ensuring correct service calls and results.