### PR TITLE
feat: add setCardDone mutation

### DIFF
--- a/backend/prisma/migrations/20260205153103_add_card_done_flag/migration.sql
+++ b/backend/prisma/migrations/20260205153103_add_card_done_flag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Card" ADD COLUMN     "done" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Card {
   archived        Boolean   @default(false)
   archivedPosition Int?     // Store original position when archived
   dueDate         DateTime? // Due date for the card
+  done            Boolean   @default(false) // Done flag for the card
   listId          String
   list            List      @relation(fields: [listId], references: [id], onDelete: Cascade)
   comments        Comment[]

--- a/backend/src/boards/models/card.model.ts
+++ b/backend/src/boards/models/card.model.ts
@@ -24,6 +24,9 @@ export class CardModel {
   @Field(() => Date, { nullable: true })
   dueDate?: Date | null;
 
+  @Field(() => Boolean)
+  done!: boolean;
+
   @Field(() => ID)
   listId!: string;
 

--- a/backend/src/cards/cards.resolver.spec.ts
+++ b/backend/src/cards/cards.resolver.spec.ts
@@ -13,6 +13,7 @@ describe('CardsResolver', () => {
     removeLabelFromCard: jest.fn(),
     setCardDueDate: jest.fn(),
     clearCardDueDate: jest.fn(),
+    setCardDone: jest.fn(),
   } as unknown as CardsService;
   const resolver = new CardsResolver(cardsService);
 
@@ -262,6 +263,27 @@ describe('CardsResolver', () => {
     const result = await resolver.clearCardDueDate(input, user);
 
     expect(cardsService.clearCardDueDate).toHaveBeenCalledWith('card-1', 'user-1');
+    expect(result).toBe(card);
+  });
+
+  it('sets done flag on a card for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const input = { cardId: 'card-1', done: true };
+    const card = {
+      id: 'card-1',
+      title: 'My Card',
+      description: null,
+      position: 0,
+      done: true,
+      listId: 'list-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    cardsService.setCardDone = jest.fn().mockResolvedValue(card);
+
+    const result = await resolver.setCardDone(input, user);
+
+    expect(cardsService.setCardDone).toHaveBeenCalledWith('card-1', true, 'user-1');
     expect(result).toBe(card);
   });
 });

--- a/backend/src/cards/cards.resolver.ts
+++ b/backend/src/cards/cards.resolver.ts
@@ -9,6 +9,7 @@ import { AddLabelToCardInput } from './dto/add-label-to-card.input';
 import { RemoveLabelFromCardInput } from './dto/remove-label-from-card.input';
 import { SetCardDueDateInput } from './dto/set-card-due-date.input';
 import { ClearCardDueDateInput } from './dto/clear-card-due-date.input';
+import { SetCardDoneInput } from './dto/set-card-done.input';
 import { CardModel } from '../boards/models/card.model';
 import { CardsService } from './cards.service';
 
@@ -92,6 +93,15 @@ export class CardsResolver {
     @Context('user') user: User
   ) {
     return this.cardsService.clearCardDueDate(input.cardId, user.id);
+  }
+
+  @Mutation(() => CardModel)
+  @AuthGuard()
+  async setCardDone(
+    @Args('input', { type: () => SetCardDoneInput }) input: SetCardDoneInput,
+    @Context('user') user: User
+  ) {
+    return this.cardsService.setCardDone(input.cardId, input.done, user.id);
   }
 }
 

--- a/backend/src/cards/cards.service.spec.ts
+++ b/backend/src/cards/cards.service.spec.ts
@@ -1868,5 +1868,136 @@ describe('CardsService', () => {
       expect(prisma.card.update).not.toHaveBeenCalled();
     });
   });
+
+  describe('setCardDone', () => {
+    const cardWithList = {
+      id: 'card-1',
+      title: 'My Card',
+      description: null,
+      position: 0,
+      archived: false,
+      dueDate: null,
+      done: false,
+      listId: 'list-1',
+      list: {
+        id: 'list-1',
+        title: 'My List',
+        boardId: 'board-1',
+        board: {
+          id: 'board-1',
+          title: 'My Board',
+          workspaceId: 'workspace-1',
+          workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        },
+      },
+    };
+
+    it('sets done flag to true on a card successfully', async () => {
+      const updatedCard = {
+        ...cardWithList,
+        done: true,
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithList)
+        .mockResolvedValueOnce(updatedCard);
+      prisma.card.update = jest.fn().mockResolvedValue(updatedCard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.setCardDone('card-1', true, 'user-1');
+
+      expect(prisma.card.findUnique).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        include: {
+          list: {
+            include: {
+              board: {
+                include: {
+                  workspace: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(
+        'workspace-1',
+        'user-1'
+      );
+      expect(prisma.card.update).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        data: {
+          done: true,
+        },
+        include: {
+          list: true,
+        },
+      });
+      expect(result).toBe(updatedCard);
+      expect(result.done).toBe(true);
+    });
+
+    it('sets done flag to false on a card successfully', async () => {
+      const cardWithDoneTrue = {
+        ...cardWithList,
+        done: true,
+      };
+      const updatedCard = {
+        ...cardWithDoneTrue,
+        done: false,
+      };
+      prisma.card.findUnique = jest
+        .fn()
+        .mockResolvedValueOnce(cardWithDoneTrue)
+        .mockResolvedValueOnce(updatedCard);
+      prisma.card.update = jest.fn().mockResolvedValue(updatedCard);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: 'workspace-1', name: 'Acme', ownerId: 'user-1' },
+        membership: { userId: 'user-1', workspaceId: 'workspace-1', role: 'MEMBER' },
+      });
+
+      const result = await service.setCardDone('card-1', false, 'user-1');
+
+      expect(prisma.card.update).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        data: {
+          done: false,
+        },
+        include: {
+          list: true,
+        },
+      });
+      expect(result).toBe(updatedCard);
+      expect(result.done).toBe(false);
+    });
+
+    it('throws NotFoundException when cardId is empty', async () => {
+      await expect(service.setCardDone('', true, 'user-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when card does not exist', async () => {
+      prisma.card.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(service.setCardDone('card-1', true, 'user-1')).rejects.toThrow(
+        NotFoundException
+      );
+      expect(prisma.card.update).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      prisma.card.findUnique = jest.fn().mockResolvedValue(cardWithList);
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new ForbiddenException('Access denied')
+      );
+
+      await expect(service.setCardDone('card-1', true, 'user-2')).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(prisma.card.update).not.toHaveBeenCalled();
+    });
+  });
 });
 

--- a/backend/src/cards/cards.service.ts
+++ b/backend/src/cards/cards.service.ts
@@ -817,5 +817,49 @@ export class CardsService {
       },
     });
   }
+
+  async setCardDone(cardId: string, done: boolean, userId: string) {
+    // Validate cardId is provided
+    if (!cardId || cardId.trim() === '') {
+      throw new NotFoundException('Card ID is required');
+    }
+
+    // Find the card with its list, board and workspace
+    const card = await this.prisma.card.findUnique({
+      where: { id: cardId },
+      include: {
+        list: {
+          include: {
+            board: {
+              include: {
+                workspace: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new NotFoundException('Card not found');
+    }
+
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(
+      card.list.board.workspaceId,
+      userId
+    );
+
+    // Update the card with the done flag
+    return this.prisma.card.update({
+      where: { id: cardId },
+      data: {
+        done,
+      },
+      include: {
+        list: true,
+      },
+    });
+  }
 }
 

--- a/backend/src/cards/dto/set-card-done.input.ts
+++ b/backend/src/cards/dto/set-card-done.input.ts
@@ -1,0 +1,16 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+
+@InputType()
+export class SetCardDoneInput {
+  @Field(() => ID)
+  @IsString()
+  @IsNotEmpty()
+  cardId!: string;
+
+  @Field(() => Boolean)
+  @IsBoolean()
+  @IsNotEmpty()
+  done!: boolean;
+}
+


### PR DESCRIPTION
This pull request introduces a new "done" flag to cards, allowing users to mark cards as completed or not. The change is implemented across the database schema, backend models, GraphQL API, and service logic, with accompanying tests to ensure correct behavior and access control.

### Database and Model Updates
* Added a `done` boolean column to the `Card` table in the database schema and updated the Prisma model to include this new field with a default value of `false`. [[1]](diffhunk://#diff-8d2f4c8f6ba36c0a11380e6578c7f525da4a0ee13a4c1432e7804636a8da3df9R1-R2) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR62)

### API and Backend Logic
* Updated the GraphQL `CardModel` to expose the `done` field and added a new mutation `setCardDone` to allow users to set the done flag for a card. [[1]](diffhunk://#diff-859e7436b3c7de1d9392ec570ebdafe0f3865e46b076769e34945db805525d12R27-R29) [[2]](diffhunk://#diff-91bf8e3a44a6ffe8c05f7feba0e8d798fc117ed53bc3f291eaa86a1f0f6108cdR97-R105) [[3]](diffhunk://#diff-9bd8c2b666307aca85b51e6fe019b86e5e6e34dcb39bc04c8fc803041a3a6c80R1-R16)
* Implemented the `setCardDone` method in the `CardsService`, including validation, permission checks, and updating the card's done status in the database.

### Testing
* Added comprehensive unit tests for the `setCardDone` service method, covering success cases, validation errors, and permission checks. Also added a resolver test for the mutation. [[1]](diffhunk://#diff-26a58aec271f24c65949c12b94eb8a4392387b91792c50e69e8897ed6bc47031R1871-R2001) [[2]](diffhunk://#diff-fc43a6210fe94cd1ff6ed00585a83932089c2ea8fc30464d531c3fa810d5c793R268-R288) [[3]](diffhunk://#diff-fc43a6210fe94cd1ff6ed00585a83932089c2ea8fc30464d531c3fa810d5c793R16)