### PR TITLE
feat: add workspaceActivity query with cursor pagination

### DIFF
--- a/backend/src/activities/activities.module.ts
+++ b/backend/src/activities/activities.module.ts
@@ -1,10 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
 import { ActivitiesService } from './activities.service';
+import { ActivitiesResolver } from './activities.resolver';
 
 @Module({
-  imports: [PrismaModule],
-  providers: [ActivitiesService],
+  imports: [PrismaModule, AuthModule, forwardRef(() => WorkspacesModule)],
+  providers: [ActivitiesService, ActivitiesResolver],
   exports: [ActivitiesService],
 })
 export class ActivitiesModule {}

--- a/backend/src/activities/activities.resolver.spec.ts
+++ b/backend/src/activities/activities.resolver.spec.ts
@@ -1,0 +1,77 @@
+import { User } from '@prisma/client';
+import { ActivitiesResolver } from './activities.resolver';
+import { ActivitiesService } from './activities.service';
+
+describe('ActivitiesResolver', () => {
+  const activitiesService = {
+    getWorkspaceActivities: jest.fn(),
+  } as unknown as ActivitiesService;
+  const resolver = new ActivitiesResolver(activitiesService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries workspace activities for the current user', async () => {
+    const user = { id: 'user-1' } as User;
+    const workspaceId = 'workspace-1';
+    const limit = 20;
+    const cursor = '2024-01-01T10:00:00Z';
+
+    const feed = {
+      activities: [
+        {
+          id: 'activity-1',
+          workspaceId,
+          type: 'CARD_CREATED',
+          createdAt: new Date(),
+        },
+      ],
+      hasMore: false,
+      nextCursor: null,
+    };
+
+    activitiesService.getWorkspaceActivities = jest.fn().mockResolvedValue(feed);
+
+    const result = await resolver.workspaceActivity(workspaceId, limit, cursor, user);
+
+    expect(activitiesService.getWorkspaceActivities).toHaveBeenCalledWith(
+      workspaceId,
+      user.id,
+      limit,
+      cursor
+    );
+    expect(result).toBe(feed);
+  });
+
+  it('queries workspace activities without cursor', async () => {
+    const user = { id: 'user-1' } as User;
+    const workspaceId = 'workspace-1';
+    const limit = 20;
+
+    const feed = {
+      activities: [],
+      hasMore: false,
+      nextCursor: null,
+    };
+
+    activitiesService.getWorkspaceActivities = jest.fn().mockResolvedValue(feed);
+
+    const result = await resolver.workspaceActivity(workspaceId, limit, null, user);
+
+    expect(activitiesService.getWorkspaceActivities).toHaveBeenCalledWith(
+      workspaceId,
+      user.id,
+      limit,
+      null
+    );
+    expect(result).toBe(feed);
+  });
+
+  it('throws error when user is not authenticated', async () => {
+    await expect(
+      resolver.workspaceActivity('workspace-1', 20, null, undefined)
+    ).rejects.toThrow('User not authenticated');
+  });
+});
+

--- a/backend/src/activities/activities.resolver.ts
+++ b/backend/src/activities/activities.resolver.ts
@@ -1,0 +1,26 @@
+import { Args, Context, Int, Query, Resolver } from '@nestjs/graphql';
+import { User } from '@prisma/client';
+import { AuthGuard } from '../common/guards/gql-auth.decorator';
+import { ActivitiesService } from './activities.service';
+import { ActivityFeedModel } from './models/activity-feed.model';
+
+@Resolver(() => ActivityFeedModel)
+export class ActivitiesResolver {
+  constructor(private readonly activitiesService: ActivitiesService) {}
+
+  @Query(() => ActivityFeedModel)
+  @AuthGuard()
+  async workspaceActivity(
+    @Args('workspaceId') workspaceId: string,
+    @Args('limit', { type: () => Int, defaultValue: 20 }) limit: number,
+    @Args('cursor', { type: () => String, nullable: true }) cursor?: string | null,
+    @Context('user') user?: User
+  ) {
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+
+    return this.activitiesService.getWorkspaceActivities(workspaceId, user.id, limit, cursor);
+  }
+}
+

--- a/backend/src/activities/activities.service.spec.ts
+++ b/backend/src/activities/activities.service.spec.ts
@@ -1,16 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ActivitiesService } from './activities.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { WorkspacesService } from '../workspaces/workspaces.service';
 import { ActivityType } from './models/activity-type.enum';
 
 describe('ActivitiesService', () => {
   let service: ActivitiesService;
   let prisma: PrismaService;
+  let workspacesService: WorkspacesService;
 
   const mockPrismaService = {
     activity: {
       create: jest.fn(),
+      findMany: jest.fn(),
     },
+  };
+
+  const mockWorkspacesService = {
+    requireWorkspaceAccess: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -21,11 +28,16 @@ describe('ActivitiesService', () => {
           provide: PrismaService,
           useValue: mockPrismaService,
         },
+        {
+          provide: WorkspacesService,
+          useValue: mockWorkspacesService,
+        },
       ],
     }).compile();
 
     service = module.get<ActivitiesService>(ActivitiesService);
     prisma = module.get<PrismaService>(PrismaService);
+    workspacesService = module.get<WorkspacesService>(WorkspacesService);
   });
 
   afterEach(() => {
@@ -187,6 +199,191 @@ describe('ActivitiesService', () => {
           },
         });
       }
+    });
+  });
+
+  describe('getWorkspaceActivities', () => {
+    const workspaceId = 'workspace-1';
+    const userId = 'user-1';
+
+    beforeEach(() => {
+      workspacesService.requireWorkspaceAccess = jest.fn().mockResolvedValue({
+        workspace: { id: workspaceId, name: 'Acme' },
+        membership: { userId, workspaceId, role: 'MEMBER' },
+      });
+    });
+
+    it('returns activities for a workspace without cursor', async () => {
+      const activities = [
+        {
+          id: 'activity-1',
+          workspaceId,
+          boardId: 'board-1',
+          actorId: userId,
+          type: ActivityType.CARD_CREATED,
+          metadata: { cardId: 'card-1' },
+          createdAt: new Date('2024-01-01T10:00:00Z'),
+          workspace: { id: workspaceId, name: 'Acme' },
+          board: { id: 'board-1', title: 'My Board' },
+          actor: { id: userId, username: 'john' },
+        },
+        {
+          id: 'activity-2',
+          workspaceId,
+          boardId: null,
+          actorId: userId,
+          type: ActivityType.WORKSPACE_CREATED,
+          metadata: { name: 'Acme' },
+          createdAt: new Date('2024-01-01T09:00:00Z'),
+          workspace: { id: workspaceId, name: 'Acme' },
+          board: null,
+          actor: { id: userId, username: 'john' },
+        },
+      ];
+
+      prisma.activity.findMany = jest.fn().mockResolvedValue(activities);
+
+      const result = await service.getWorkspaceActivities(workspaceId, userId, 20);
+
+      expect(workspacesService.requireWorkspaceAccess).toHaveBeenCalledWith(workspaceId, userId);
+      expect(prisma.activity.findMany).toHaveBeenCalledWith({
+        where: { workspaceId },
+        take: 21,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          workspace: true,
+          board: true,
+          actor: true,
+        },
+      });
+      expect(result.activities).toEqual(activities);
+      expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('returns activities with cursor pagination', async () => {
+      const cursor = '2024-01-01T10:00:00Z';
+      const activities = [
+        {
+          id: 'activity-2',
+          workspaceId,
+          boardId: null,
+          actorId: userId,
+          type: ActivityType.WORKSPACE_CREATED,
+          metadata: { name: 'Acme' },
+          createdAt: new Date('2024-01-01T09:00:00Z'),
+          workspace: { id: workspaceId, name: 'Acme' },
+          board: null,
+          actor: { id: userId, username: 'john' },
+        },
+      ];
+
+      prisma.activity.findMany = jest.fn().mockResolvedValue(activities);
+
+      const result = await service.getWorkspaceActivities(workspaceId, userId, 20, cursor);
+
+      expect(prisma.activity.findMany).toHaveBeenCalledWith({
+        where: {
+          workspaceId,
+          createdAt: { lt: new Date(cursor) },
+        },
+        take: 21,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          workspace: true,
+          board: true,
+          actor: true,
+        },
+      });
+      expect(result.activities).toEqual(activities);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('indicates hasMore when there are more activities', async () => {
+      const baseDate = new Date('2024-01-01T10:00:00Z');
+      const activities = Array.from({ length: 21 }, (_, i) => ({
+        id: `activity-${i}`,
+        workspaceId,
+        boardId: null,
+        actorId: userId,
+        type: ActivityType.CARD_CREATED,
+        metadata: null,
+        createdAt: new Date(baseDate.getTime() - i * 60000), // Subtract i minutes
+        workspace: { id: workspaceId, name: 'Acme' },
+        board: null,
+        actor: { id: userId, username: 'john' },
+      }));
+
+      prisma.activity.findMany = jest.fn().mockResolvedValue(activities);
+
+      const result = await service.getWorkspaceActivities(workspaceId, userId, 20);
+
+      expect(result.activities).toHaveLength(20);
+      expect(result.hasMore).toBe(true);
+      expect(result.nextCursor).toBe(activities[19].createdAt.toISOString());
+    });
+
+    it('limits results to maximum 100', async () => {
+      prisma.activity.findMany = jest.fn().mockResolvedValue([]);
+
+      await service.getWorkspaceActivities(workspaceId, userId, 200);
+
+      expect(prisma.activity.findMany).toHaveBeenCalledWith({
+        where: { workspaceId },
+        take: 101, // limit + 1
+        orderBy: { createdAt: 'desc' },
+        include: {
+          workspace: true,
+          board: true,
+          actor: true,
+        },
+      });
+    });
+
+    it('ensures minimum limit of 1', async () => {
+      prisma.activity.findMany = jest.fn().mockResolvedValue([]);
+
+      await service.getWorkspaceActivities(workspaceId, userId, 0);
+
+      expect(prisma.activity.findMany).toHaveBeenCalledWith({
+        where: { workspaceId },
+        take: 2, // 1 + 1
+        orderBy: { createdAt: 'desc' },
+        include: {
+          workspace: true,
+          board: true,
+          actor: true,
+        },
+      });
+    });
+
+    it('ignores invalid cursor format', async () => {
+      const invalidCursor = 'invalid-date';
+      prisma.activity.findMany = jest.fn().mockResolvedValue([]);
+
+      await service.getWorkspaceActivities(workspaceId, userId, 20, invalidCursor);
+
+      expect(prisma.activity.findMany).toHaveBeenCalledWith({
+        where: { workspaceId },
+        take: 21,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          workspace: true,
+          board: true,
+          actor: true,
+        },
+      });
+    });
+
+    it('throws ForbiddenException when user is not a workspace member', async () => {
+      workspacesService.requireWorkspaceAccess = jest.fn().mockRejectedValue(
+        new Error('Access denied')
+      );
+
+      await expect(
+        service.getWorkspaceActivities(workspaceId, userId, 20)
+      ).rejects.toThrow('Access denied');
+      expect(prisma.activity.findMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/activities/activities.service.ts
+++ b/backend/src/activities/activities.service.ts
@@ -1,10 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ActivityType } from './models/activity-type.enum';
+import { WorkspacesService } from '../workspaces/workspaces.service';
 
 @Injectable()
 export class ActivitiesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(forwardRef(() => WorkspacesService))
+    private readonly workspacesService: WorkspacesService
+  ) {}
 
   async logActivity(params: {
     workspaceId: string;
@@ -40,6 +45,63 @@ export class ActivitiesService {
         actor: true,
       },
     });
+  }
+
+  async getWorkspaceActivities(
+    workspaceId: string,
+    userId: string,
+    limit: number,
+    cursor?: string | null
+  ) {
+    // Check if user is a member of the workspace (throws ForbiddenException if not)
+    await this.workspacesService.requireWorkspaceAccess(workspaceId, userId);
+
+    // Validate limit (should be between 1 and 100)
+    const validLimit = Math.min(Math.max(1, limit), 100);
+
+    // Build where clause
+    const where: {
+      workspaceId: string;
+      createdAt?: { lt: Date };
+    } = {
+      workspaceId,
+    };
+
+    // If cursor is provided, decode it (cursor is ISO date string)
+    if (cursor) {
+      try {
+        const cursorDate = new Date(cursor);
+        if (!isNaN(cursorDate.getTime())) {
+          where.createdAt = { lt: cursorDate };
+        }
+      } catch {
+        // Invalid cursor format, ignore it
+      }
+    }
+
+    // Fetch activities ordered by createdAt descending (most recent first)
+    const activities = await this.prisma.activity.findMany({
+      where,
+      take: validLimit + 1, // Fetch one extra to check if there are more
+      orderBy: {
+        createdAt: 'desc',
+      },
+      include: {
+        workspace: true,
+        board: true,
+        actor: true,
+      },
+    });
+
+    // Check if there are more activities
+    const hasMore = activities.length > validLimit;
+    const result = hasMore ? activities.slice(0, validLimit) : activities;
+
+    return {
+      activities: result,
+      hasMore,
+      nextCursor: hasMore && result.length > 0 ? result[result.length - 1].createdAt.toISOString() : null,
+    };
   }
 }
 

--- a/backend/src/activities/models/activity-feed.model.ts
+++ b/backend/src/activities/models/activity-feed.model.ts
@@ -1,0 +1,15 @@
+import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { ActivityModel } from './activity.model';
+
+@ObjectType()
+export class ActivityFeedModel {
+  @Field(() => [ActivityModel])
+  activities!: ActivityModel[];
+
+  @Field(() => Boolean)
+  hasMore!: boolean;
+
+  @Field(() => String, { nullable: true })
+  nextCursor?: string | null;
+}
+

--- a/backend/src/workspaces/workspaces.module.ts
+++ b/backend/src/workspaces/workspaces.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { ActivitiesModule } from '../activities/activities.module';
 import './models/workspace-role.enum';
@@ -6,7 +6,7 @@ import { WorkspacesResolver } from './workspaces.resolver';
 import { WorkspacesService } from './workspaces.service';
 
 @Module({
-  imports: [AuthModule, ActivitiesModule],
+  imports: [AuthModule, forwardRef(() => ActivitiesModule)],
   providers: [WorkspacesResolver, WorkspacesService],
   exports: [WorkspacesService],
 })

--- a/backend/src/workspaces/workspaces.service.ts
+++ b/backend/src/workspaces/workspaces.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable, NotFoundException, forwardRef } from '@nestjs/common';
 import { Workspace, WorkspaceMember, WorkspaceRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { ActivitiesService } from '../activities/activities.service';
@@ -8,6 +8,7 @@ import { ActivityType } from '../activities/models/activity-type.enum';
 export class WorkspacesService {
   constructor(
     private readonly prisma: PrismaService,
+    @Inject(forwardRef(() => ActivitiesService))
     private readonly activitiesService: ActivitiesService
   ) {}
 


### PR DESCRIPTION
This pull request introduces a paginated activity feed for workspaces, including a new GraphQL query, service method, and comprehensive tests. It also resolves circular dependencies between the `ActivitiesModule` and `WorkspacesModule` using NestJS's `forwardRef`. The changes are grouped into three main themes: new feature implementation, testing, and dependency management.

**New feature: Workspace activity feed with pagination**
- Added a new GraphQL query `workspaceActivity` in `ActivitiesResolver`, which returns a paginated activity feed for a workspace, requiring user authentication and membership. The query supports cursor-based pagination and validates input parameters. (`backend/src/activities/activities.resolver.ts`, `backend/src/activities/models/activity-feed.model.ts`) [[1]](diffhunk://#diff-44425c61a7f81a21a2aaa6b5a171ce745ca476215bb6eef9f9ccda1a85b43f34R1-R26) [[2]](diffhunk://#diff-7b396787711a935c4d217c20f188448f7d44b60dffb9f415ed8da5e39be08885R1-R15)
- Implemented `getWorkspaceActivities` in `ActivitiesService`, which checks workspace access, validates and enforces pagination limits, handles cursor logic, and returns activity data with pagination info. (`backend/src/activities/activities.service.ts`)

**Testing improvements**
- Added comprehensive unit tests for `ActivitiesResolver` and `ActivitiesService`, covering authentication, pagination, cursor handling, and error cases. (`backend/src/activities/activities.resolver.spec.ts`, `backend/src/activities/activities.service.spec.ts`) [[1]](diffhunk://#diff-1b28380d98ec198c2341d112dab7db43d8f762533a180fc141fd4de932c501c7R1-R77) [[2]](diffhunk://#diff-ab1379de7642ed396d75895861f77d34fb55d6c52ecefcaf6feeda816b55903dR4-R22) [[3]](diffhunk://#diff-ab1379de7642ed396d75895861f77d34fb55d6c52ecefcaf6feeda816b55903dR31-R40) [[4]](diffhunk://#diff-ab1379de7642ed396d75895861f77d34fb55d6c52ecefcaf6feeda816b55903dR204-R388)

**Dependency management and module wiring**
- Updated `ActivitiesModule` and `WorkspacesModule` to use `forwardRef` for each other's imports and constructor injections, resolving circular dependency issues and ensuring proper DI of services. (`backend/src/activities/activities.module.ts`, `backend/src/activities/activities.service.ts`, `backend/src/workspaces/workspaces.module.ts`, `backend/src/workspaces/workspaces.service.ts`) [[1]](diffhunk://#diff-127554436e52916abb856e1d462490f483231c5f231d0fdc23ef53a093ad5e33L1-R10) [[2]](diffhunk://#diff-093d0d63f1966bcc35fa6a7520c57ed4203eecb4cfb9a06bd8bed27d1350483dL1-R12) [[3]](diffhunk://#diff-7b4686f11950c326c46f0f0ff748fbf5571eb7a3bc7c15cd78cef5e4b386f63aL1-R9) [[4]](diffhunk://#diff-2cc0ece44c713873ef8faaabbb96a57483078a41893e4f77abd40e71044427ddL1-R1) [[5]](diffhunk://#diff-2cc0ece44c713873ef8faaabbb96a57483078a41893e4f77abd40e71044427ddR11)